### PR TITLE
[feat] PageUp 버튼 컴포넌트 추가

### DIFF
--- a/src/components/common/PageUpBtn.tsx
+++ b/src/components/common/PageUpBtn.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
 interface PageUpBtnProps {
@@ -32,7 +33,7 @@ const PageUpBtn = ({ scrollPosition }: PageUpBtnProps) => {
   return (
     <>
       {isVisible && (
-        <img src="https://cdn-icons-png.flaticon.com/512/892/892692.png" width={30} onClick={handlePageUp} />
+        <Image src="https://via.placeholder.com/30x30" alt="" width={30} height={30} onClick={handlePageUp} />
       )}
     </>
   );

--- a/src/components/common/PageUpBtn.tsx
+++ b/src/components/common/PageUpBtn.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface PageUpBtnProps {
+  scrollPosition: number;
+}
+const PageUpBtn = ({ scrollPosition }: PageUpBtnProps) => {
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+
+  const handlePageUp = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
+
+  useEffect(() => {
+    const showButton = () => {
+      if (scrollPosition > 400) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+    window.addEventListener('scroll', showButton);
+    return () => {
+      window.removeEventListener('scroll', showButton);
+    };
+  }, [scrollPosition]);
+
+  return (
+    <>
+      {isVisible && (
+        <img src="https://cdn-icons-png.flaticon.com/512/892/892692.png" width={30} onClick={handlePageUp} />
+      )}
+    </>
+  );
+};
+
+export default PageUpBtn;

--- a/src/components/quiz-form/QuizForm.tsx
+++ b/src/components/quiz-form/QuizForm.tsx
@@ -116,7 +116,7 @@ const QuizForm = () => {
           <button type="submit">등록하기</button>
         </div>
       </form>
-      <div style={{ position: 'fixed', bottom: '20px', left: '20px;' }}>
+      <div style={{ position: 'fixed', bottom: '20px', right: '20px;' }}>
         <PageUpBtn scrollPosition={scrollPosition} />
       </div>
     </main>

--- a/src/components/quiz-form/QuizForm.tsx
+++ b/src/components/quiz-form/QuizForm.tsx
@@ -1,20 +1,41 @@
 'use client';
 
-import { useRef, useState } from 'react';
 import QuestionForm from './QuestionForm';
 import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
+
+import type { Option, Question, Quiz } from '@/types/quizzes';
+import PageUpBtn from '../common/PageUpBtn';
 
 const QuizForm = () => {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [options, setOptions] = useState<Option[]>([]);
+  const [scrollPosition, setScrollPosition] = useState<number>(0);
+
   const [level, setLevel] = useState<number>(0);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [selectedImg, setSelectedImg] = useState('https://via.placeholder.com/288x208');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrollPosition(window.scrollY);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [scrollPosition]);
+
+  /** 썸네일 이미지 클릭 이벤트 */
   const handleImgClick = () => {
     fileInputRef.current?.click();
   };
 
+  /** 썸네일 이미지 클릭하여 이미지 파일 첨부하기 */
   const handleImgChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -26,6 +47,7 @@ const QuizForm = () => {
     }
   };
 
+  /** 등록 버튼 클릭 핸들러 */
   const handleSubmitBtn = () => {
     if (!level) {
       alert('난이도를 선택해주세요.');
@@ -46,7 +68,7 @@ const QuizForm = () => {
   };
 
   return (
-    <main className="bg-rose-100 p-5">
+    <main className="bg-rose-100 p-5 flex gap-5 h-[2000px]">
       <form
         className="flex flex-col"
         onSubmit={(e) => {
@@ -86,12 +108,17 @@ const QuizForm = () => {
             />
           </div>
         </div>
-        <QuestionForm />
+        <div className="">
+          <QuestionForm questions={questions} setQuestions={setQuestions} options={options} setOptions={setOptions} />
+        </div>
         <div className="flex gap-2">
           <button type="button">취소하기</button>
           <button type="submit">등록하기</button>
         </div>
       </form>
+      <div style={{ position: 'fixed', bottom: '20px', left: '20px;' }}>
+        <PageUpBtn scrollPosition={scrollPosition} />
+      </div>
     </main>
   );
 };

--- a/src/types/quizzes.ts
+++ b/src/types/quizzes.ts
@@ -1,0 +1,30 @@
+export enum QuestionType {
+  subjective,
+  objective
+}
+
+export type Option = {
+  id: string;
+  questionId: string;
+  content: string;
+  isAnswer: boolean;
+};
+
+export type Question = {
+  id: string;
+  quizId: string; //????????
+  type: QuestionType;
+  title: string;
+  imgUrl?: string;
+  correctAnswer?: string;
+  // options?: Option[];
+};
+
+export type Quiz = {
+  id: string;
+  creatorId: string;
+  level: number;
+  title: string;
+  info: string;
+  thumbnailImgUrl?: string;
+};

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -1,0 +1,74 @@
+import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { type NextRequest, NextResponse } from 'next/server';
+export const updateSession = async (request: NextRequest) => {
+  // This `try/catch` block is only here for the interactive tutorial.
+  // Feel free to remove once you have Supabase connected.
+  try {
+    // Create an unmodified response
+    let response = NextResponse.next({
+      request: {
+        headers: request.headers
+      }
+    });
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          get(name: string) {
+            return request.cookies.get(name)?.value;
+          },
+          set(name: string, value: string, options: CookieOptions) {
+            // If the cookie is updated, update the cookies for the request and response
+            request.cookies.set({
+              name,
+              value,
+              ...options
+            });
+            response = NextResponse.next({
+              request: {
+                headers: request.headers
+              }
+            });
+            response.cookies.set({
+              name,
+              value,
+              ...options
+            });
+          },
+          remove(name: string, options: CookieOptions) {
+            // If the cookie is removed, update the cookies for the request and response
+            request.cookies.set({
+              name,
+              value: '',
+              ...options
+            });
+            response = NextResponse.next({
+              request: {
+                headers: request.headers
+              }
+            });
+            response.cookies.set({
+              name,
+              value: '',
+              ...options
+            });
+          }
+        }
+      }
+    );
+    // This will refresh session if expired - required for Server Components
+    // https://supabase.com/docs/guides/auth/server-side/nextjs
+    await supabase.auth.getUser();
+    return response;
+  } catch (e) {
+    // If you are here, a Supabase client could not be created!
+    // This is likely because you have not set up environment variables.
+    // Check out http://localhost:3000 for Next Steps.
+    return NextResponse.next({
+      request: {
+        headers: request.headers
+      }
+    });
+  }
+};


### PR DESCRIPTION
## 📍 관련 이슈
#11 

## ✍️ Task TODOLIST
- [x] components/PageUpBtn.tsx 생성
- [x] 일정 스크롤 이상 내려가면 visible (현재 400px로 설정되어 있습니다)
- [x] 화면 우하단 고정
- [ ] 디자인 적용

## 🧑🏻‍💻 개발 내용
* `components / common/ PageUpBtn.tsx` 입니다. 스크롤이 아래로 400px 이상 이동되면 이미지가 표시되고, 이미지를 클릭하면 맨 위로 스크롤이 이동합니다.

* 현재 임시 이미지 & 임시 크기 적용되어 있습니다.

* 사용하시는 방법:
1. 컴포넌트에 스크롤 위치를 추적하기 위한 상태를 만듭니다. (클라이언트 컴포넌트 필수)
```
const [scrollPosition, setScrollPosition] = useState<number>(0);
```

2. 스크롤을 감지하는 useEffect 훅을 작성해줍니다.
```
  useEffect(() => {
    const handleScroll = () => {
      setScrollPosition(window.scrollY);
    };

    window.addEventListener('scroll', handleScroll, { passive: true });

    return () => {
      window.removeEventListener('scroll', handleScroll);
    };
  }, [scrollPosition]);
```

3. PageUpBtn 컴포넌트를 찾기 편하신 곳에 넣어주고, 위치를 고정해줍니다. 아래의 내용으로 입력하시면 우하단에 고정됩니다.
```
      <div style={{ position: 'fixed', bottom: '20px', right: '20px;' }}>
        <PageUpBtn scrollPosition={scrollPosition} />
      </div>
```

## 📸 스크린샷(선택)
![image](https://github.com/mm-easy/mm-easy/assets/153061626/1cceecc1-a915-4426-a20e-ae2a79171939)
