### PR TITLE
[feat] 회원가입시 profiles 에 정보 추가, 로그인 기능 구현

### DIFF
--- a/src/app/(non-auth)/login/page.tsx
+++ b/src/app/(non-auth)/login/page.tsx
@@ -1,13 +1,31 @@
+"use client"
+import { useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth'; 
 
 const LoginPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { signIn, loading, error } = useAuth(); 
+  const router = useRouter();
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await signIn(email, password);
+    
+    if (!error) {
+      router.push('/'); 
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
       <div className="w-full max-w-md p-8 bg-white shadow-lg rounded-2xl">
         <div className="flex items-center justify-center w-24 h-24 mx-auto mb-4 bg-black rounded-full">
           {/* 고양이 예시 */}
         </div>
-        <form className="space-y-6">
+        <form className="space-y-6" onSubmit={handleLogin}>
           <div>
             <label htmlFor="email" className="text-sm font-medium text-gray-700">
               ID
@@ -19,6 +37,8 @@ const LoginPage = () => {
                 className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring focus:border-blue-300"
                 placeholder="you@example.com"
                 autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)} 
               />
             </div>
           </div>
@@ -33,13 +53,17 @@ const LoginPage = () => {
                 className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring focus:border-blue-300"
                 placeholder="••••••••"
                 autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)} 
               />
             </div>
           </div>
+          {error && <div className="text-red-500">{error}</div>}
           <div>
             <button 
               type="submit" 
               className="w-full px-4 py-2 text-white bg-black rounded-md shadow hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-black"
+              disabled={loading} 
             >
               로그인
             </button>

--- a/src/app/(non-auth)/signup/page.tsx
+++ b/src/app/(non-auth)/signup/page.tsx
@@ -1,14 +1,16 @@
 "use client"
 import Link from 'next/link';
 import { useState } from 'react';
-import { useSignUp } from '@/hooks/useAuth';
+import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'react-toastify';
+import { useRouter } from 'next/navigation';
 
 const SignUpPage = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const { signUp } = useSignUp(); 
+  const { signUp } = useAuth(); 
+  const router = useRouter();
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -16,9 +18,14 @@ const SignUpPage = () => {
       toast.error('비밀번호가 서로 일치하지 않습니다.'); 
       return;
     }
+    if (password.length < 6) {
+      toast.error('비밀번호는 최소 6자 이상이어야 합니다.');
+      return;
+    }
     try {
       await signUp(email, password);
       toast.success('회원가입에 성공했습니다!'); 
+      router.push('/login');
     } catch (error) {
     }
   };
@@ -58,7 +65,6 @@ const SignUpPage = () => {
                 placeholder="Create a password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                autoComplete="new-password"
               />
             </div>
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,23 @@
+"use client"
+
+import { useAuth } from "@/hooks/useAuth";
+import { toast } from "react-toastify";
+
 const Header = () => {
-  return <div>Header</div>;
+  const { logout } = useAuth();
+  const handleLogout = async () => {
+    await logout();
+    toast.success('로그아웃되었습니다.');
+  }
+
+  return (
+    <div>
+      Header
+      <button onClick={handleLogout} className="ml-10">
+        로그아웃
+      </button>
+    </div>
+  );
 };
 
 export default Header;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { supabase } from '../utils/supabase/supabase';
 
-export const useSignUp = () => {
+export const useAuth = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -20,7 +20,7 @@ export const useSignUp = () => {
       return;
     }
 
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
     });
@@ -29,7 +29,51 @@ export const useSignUp = () => {
     else setError(null);
 
     setLoading(false);
+
+    if (data.user) {
+        const nickname = email.split('@')[0];
+        const { error: insertError } = await supabase
+          .from('profiles')
+          .insert([{ id: data.user.id, email, nickname }]);
+    
+        if (insertError) {
+          setError(insertError.message);
+        }
+      } else {
+        setError('회원가입에 성공했으나 사용자 정보를 불러올 수 없습니다.');
+      }
+    
+      setLoading(false);
   };
 
-  return { signUp, loading, error, setError };
+  const signIn = async (email: string, password: string) => {
+    setLoading(true);
+    setError(null);
+
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (error) {
+      setError(error.message);
+    } else {
+      setError(null);
+    }
+
+    setLoading(false);
+  };
+
+  const logout = async () => {
+    setLoading(true);
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      setError(error.message);
+    } else {
+      setError(null);
+    }
+    setLoading(false);
+  };
+
+  return { signUp, signIn, logout, loading, error, setError };
 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -14,11 +14,6 @@ export const useAuth = () => {
       setLoading(false);
       return;
     }
-    if (password.length < 6) {
-      setError('비밀번호는 6자리 이상이어야 합니다.');
-      setLoading(false);
-      return;
-    }
 
     const { data, error } = await supabase.auth.signUp({
       email,

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,0 +1,8 @@
+import { UUID } from "crypto";
+
+export type User = {
+    id:UUID;
+    email: string;
+    nickname: string;
+    avatar_img_url: string;
+};


### PR DESCRIPTION
## 📍 관련 이슈
#20 

## ✍️ Task TODOLIST

- [x] 회원가입 정보 profiles에 추가
- [x]  로그인 기능 구현
- [ ]  회원가입시 중복 가입 방지
- [x]  로그아웃 기능
- [ ]  임의의 아바타 추가

## 🚨 TroubleShotting

로그인시 이메일 확인이 안됫다는 문구가 출력되며 로그인이 되지않는 상황이 발생함
- 회원가입시 supabase 이메일 확인이 켜져있는것이 문제발생의 이유 이메일 확인 비활성화로 해결

회원가입시 정보가 profiles 테이블에 추가되지않는 문제 발생
- supabase profiles 테이블의 RLS 를 disable 함으로 해결

## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
임의로 이메일을 만들어 회원가입할시 supabase 이메일 확인을 꺼둘것!
