### PR TITLE
[feat] 선택지 체크 시 정답으로 설정, 헤더 로고 클릭 시 홈으로 이동

### DIFF
--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -169,7 +169,6 @@ const QuestionForm = ({
                       <div key={option.id}>
                         <input
                           type="checkbox"
-                          name={id}
                           checked={option.isAnswer}
                           onChange={() => {
                             handleCheckObjectAnswer(id, options, option.id);

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -86,14 +86,14 @@ const QuestionForm = ({
   };
 
   /** 객관식 정답 체크 핸들러 */
-  const handleCheckObjectAnswer = (id: string, options: Option[], optionId: string, isAnswer: boolean) => {
+  const handleCheckObjectAnswer = (id: string, options: Option[], optionId: string) => {
     setQuestions((prev) =>
       prev.map((question) => {
         return question.id === id
           ? {
               ...question,
               options: options.map((option) => {
-                return option.id === optionId ? { ...option, isAnswer: !isAnswer } : { ...option, isAnswer: false };
+                return option.id === optionId ? { ...option, isAnswer: true } : { ...option, isAnswer: false };
               })
             }
           : question;
@@ -171,9 +171,8 @@ const QuestionForm = ({
                           type="checkbox"
                           name={id}
                           checked={option.isAnswer}
-                          onChange={(e) => {
-                            e.preventDefault();
-                            handleCheckObjectAnswer(id, options, option.id, option.isAnswer);
+                          onChange={() => {
+                            handleCheckObjectAnswer(id, options, option.id);
                           }}
                         />
                         <input

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -86,12 +86,20 @@ const QuestionForm = ({
   };
 
   /** 객관식 정답 체크 핸들러 */
-  // const handleCheckObjectAnswer = (id: string, checkedOption: HTMLInputElement, optionId: string) => {
-  //   const checkboxes = document.getElementsByName(optionId)
-  //   checkboxes.forEach(checkbox=>{
-  //     checkbox === checkedOption ? checkbox.checked=true
-  //   })
-  // };
+  const handleCheckObjectAnswer = (id: string, options: Option[], optionId: string, isAnswer: boolean) => {
+    setQuestions((prev) =>
+      prev.map((question) => {
+        return question.id === id
+          ? {
+              ...question,
+              options: options.map((option) => {
+                return option.id === optionId ? { ...option, isAnswer: !isAnswer } : { ...option, isAnswer: false };
+              })
+            }
+          : question;
+      })
+    );
+  };
 
   /** 주관식 정답 입력 핸들러 */
   const handleChangeCorrectAnswer = (id: string, correctAnswer: string) => {
@@ -127,18 +135,14 @@ const QuestionForm = ({
                 <label>
                   <input
                     type="radio"
-                    name={`radio${id}`}
+                    name={id}
                     defaultChecked
                     onChange={() => handleChangeType(id, QuestionType.objective)}
                   />
                   객관식
                 </label>
                 <label>
-                  <input
-                    type="radio"
-                    name={`radio${id}`}
-                    onChange={() => handleChangeType(id, QuestionType.subjective)}
-                  />
+                  <input type="radio" name={id} onChange={() => handleChangeType(id, QuestionType.subjective)} />
                   주관식
                 </label>
               </section>
@@ -165,10 +169,11 @@ const QuestionForm = ({
                       <div key={option.id}>
                         <input
                           type="checkbox"
-                          name={`checkbox${id}`}
+                          name={id}
+                          checked={option.isAnswer}
                           onChange={(e) => {
                             e.preventDefault();
-                            // handleCheckObjectAnswer(id, e.target, option.id);
+                            handleCheckObjectAnswer(id, options, option.id, option.isAnswer);
                           }}
                         />
                         <input

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -127,14 +127,18 @@ const QuestionForm = ({
                 <label>
                   <input
                     type="radio"
-                    name={id}
+                    name={`radio${id}`}
                     defaultChecked
                     onChange={() => handleChangeType(id, QuestionType.objective)}
                   />
                   객관식
                 </label>
                 <label>
-                  <input type="radio" name={id} onChange={() => handleChangeType(id, QuestionType.subjective)} />
+                  <input
+                    type="radio"
+                    name={`radio${id}`}
+                    onChange={() => handleChangeType(id, QuestionType.subjective)}
+                  />
                   주관식
                 </label>
               </section>
@@ -161,7 +165,7 @@ const QuestionForm = ({
                       <div key={option.id}>
                         <input
                           type="checkbox"
-                          name={option.id}
+                          name={`checkbox${id}`}
                           onChange={(e) => {
                             e.preventDefault();
                             // handleCheckObjectAnswer(id, e.target, option.id);

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -31,22 +31,6 @@ const QuestionForm = ({
     );
   };
 
-  /** 선택지 입력 핸들러 */
-  const handleChangeOption = (id: string, content: string, options: Option[], optionId: string) => {
-    setQuestions((prev) =>
-      prev.map((question) => {
-        return question.id === id
-          ? {
-              ...question,
-              options: options.map((option) => {
-                return option.id === optionId ? { ...option, content } : option;
-              })
-            }
-          : question;
-      })
-    );
-  };
-
   /** 선택지 추가 핸들러 */
   const handleAddOption = (id: string, options: Option[]) => {
     if (options.length < 5) {
@@ -70,6 +54,22 @@ const QuestionForm = ({
     }
   };
 
+  /** 선택지 입력 핸들러 */
+  const handleChangeOption = (id: string, content: string, options: Option[], optionId: string) => {
+    setQuestions((prev) =>
+      prev.map((question) => {
+        return question.id === id
+          ? {
+              ...question,
+              options: options.map((option) => {
+                return option.id === optionId ? { ...option, content } : option;
+              })
+            }
+          : question;
+      })
+    );
+  };
+
   /** 선택지 삭제 핸들러 */
   const handleDeleteOption = (id: string, options: Option[], optionId: string) => {
     if (options.length > 2) {
@@ -84,6 +84,14 @@ const QuestionForm = ({
       toast.warn('최소 2개의 선택지가 있어야 합니다.');
     }
   };
+
+  /** 객관식 정답 체크 핸들러 */
+  // const handleCheckObjectAnswer = (id: string, checkedOption: HTMLInputElement, optionId: string) => {
+  //   const checkboxes = document.getElementsByName(optionId)
+  //   checkboxes.forEach(checkbox=>{
+  //     checkbox === checkedOption ? checkbox.checked=true
+  //   })
+  // };
 
   /** 주관식 정답 입력 핸들러 */
   const handleChangeCorrectAnswer = (id: string, correctAnswer: string) => {
@@ -151,6 +159,14 @@ const QuestionForm = ({
                   {options.map((option) => {
                     return (
                       <div key={option.id}>
+                        <input
+                          type="checkbox"
+                          name={option.id}
+                          onChange={(e) => {
+                            e.preventDefault();
+                            // handleCheckObjectAnswer(id, e.target, option.id);
+                          }}
+                        />
                         <input
                           type="text"
                           style={{ width: '500px', marginBottom: '10px' }}

--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -64,8 +64,8 @@ const QuizForm = () => {
     }
   ]);
 
-  console.log('1', questions[0].options);
-  console.log('2', questions[1].options);
+  // console.log('1', questions[0].options);
+  // console.log('2', questions[1].options);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,14 +1,14 @@
-"use client"
+'use client';
 
-import { useAuth } from "@/hooks/useAuth";
-import { toast } from "react-toastify";
+import { useAuth } from '@/hooks/useAuth';
+import { toast } from 'react-toastify';
 
 const Header = () => {
   const { logout } = useAuth();
   const handleLogout = async () => {
     await logout();
     toast.success('로그아웃되었습니다.');
-  }
+  };
 
   return (
     <div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useAuth } from '@/hooks/useAuth';
+import Link from 'next/link';
 import { toast } from 'react-toastify';
 
 const Header = () => {
@@ -13,7 +14,7 @@ const Header = () => {
   return (
     <section className="bg-bgColor1 border-solid border-b border-pointColor1 p-5 pl-10 pr-10 min-h-20 flex items-end justify-between">
       <button>MENU</button>
-      <p>로고ㅎ</p>
+      <Link href="/">로고ㅎ</Link>
       <button onClick={handleLogout} className="ml-10">
         로그아웃
       </button>


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-131
🔗 https://coding-legend.atlassian.net/browse/MMEASY-118
🔗 https://coding-legend.atlassian.net/browse/MMEASY-122

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 선택지 체크 하나만 되도록
- [x] 체크한 선택지는 정답으로, 나머지는 오답으로 setState
- [x] input checkbox name 속성 삭제
- [x] 헤더 로고 클릭 시 홈으로 이동

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- 체크박스들을 따로 모아서 정답, 오답별로 state 변경을 해야 하나..? 했는데
그냥 옵션에 isAnswer 를 내려주면 되는 문제였습니다.. (체크 하나씩, 정답 처리가 같이 해결되었어요 🥹)
- name 속성은 지금 필요없는 것 같아서 지웠습니다!

QuestionForm.tsx
```tsx
<input
    type="checkbox"
    checked={option.isAnswer}
    onChange={() => {
    handleCheckObjectAnswer(id, options, option.id);
  }}
/>
```

## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
- 리액트 체크박스 검색하다 찾은 영상인데 7분즈음 disabled 약관동의에 활용하면 좋을거 같아요.
근데 지금 toast도 좋습니다.. 한 번 고민을..!

🔗 https://www.youtube.com/watch?v=w7gIFDw0Hoc