### PR TITLE
[feat] 헤더 로그인 상태에 따라 로그인,로그아웃 조건부 렌더링

### DIFF
--- a/src/app/(non-auth)/login/page.tsx
+++ b/src/app/(non-auth)/login/page.tsx
@@ -31,7 +31,7 @@ const LoginPage = () => {
   };
 
   return (
-    <div className="flex min-h-screen bg-red-100">
+    <div className="flex min-h-screen bg-bgColor1">
     <div className="flex-1 flex items-center justify-center">
       <div className="w-80 h-80 bg-gray-400 rounded-full flex items-center justify-center">
         {/* 고양이 예시 */}
@@ -48,7 +48,7 @@ const LoginPage = () => {
                 id="email"
                 type="email" 
                 required
-                className="w-full px-3 py-4 border border-blue-700 shadow-sm focus:outline-none focus:ring focus:border-blue-300"
+                className="w-full px-3 py-4 border border-pointColor1 shadow-sm focus:outline-none focus:ring focus:border-blue-300"
                 placeholder="you@example.com"
                 autoComplete="email"
                 value={email}
@@ -64,7 +64,7 @@ const LoginPage = () => {
                 id="password"
                 type="password" 
                 required
-                className="w-full px-3 py-4 border border-blue-700 shadow-sm focus:outline-none focus:ring focus:border-blue-300"
+                className="w-full px-3 py-4 border border-pointColor1 shadow-sm focus:outline-none focus:ring focus:border-blue-300"
                 placeholder="••••••••"
                 autoComplete="current-password"
                 value={password}
@@ -74,17 +74,17 @@ const LoginPage = () => {
           </div>
           {error && <div className="text-red-500">{error}</div>}
           <div className="flex mt-6 justify-between">
-          <Link className="text-sm font-medium text-blue-600 hover:underline" href="/terms">
+          <Link className="text-sm font-medium text-pointColor1 hover:underline" href="/terms">
               회원가입
           </Link>
-          <Link className="text-sm font-medium text-blue-600 hover:underline" href="/">
+          <Link className="text-sm font-medium text-pointColor1 hover:underline" href="/">
               아이디 찾기 | 비밀번호 찾기
           </Link>
         </div>
           <div>
             <button 
               type="submit" 
-              className="w-full px-4 py-5 text-white bg-blue-700 shadow hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-black"
+              className="w-full px-4 py-5 text-white bg-pointColor1 shadow hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-black"
               disabled={loading} 
             >
               로그인
@@ -94,13 +94,13 @@ const LoginPage = () => {
         <div className="flex justify-center mt-3">
         <button 
           onClick={handleGoogleSignIn}
-          className="flex items-center justify-center w-full mr-3 px-1 py-3 text-blue-700 border border-blue-700 hover:bg-gray-300 rounded-md shadow"
+          className="flex items-center justify-center w-full mr-3 px-1 py-3 text-pointColor1 border border-pointColor1 hover:bg-gray-300 rounded-md shadow"
         >
           <FcGoogle className="mr-2" size="2em" />Google 로그인
         </button>
         <button
           onClick={handleKakaoSignIn}
-          className="flex items-center justify-center w-full px-1 py-3 text-blue-700 border border-blue-700 hover:bg-gray-300 rounded-md shadow"
+          className="flex items-center justify-center w-full px-1 py-3 text-pointColor1 border border-pointColor1 hover:bg-gray-300 rounded-md shadow"
         >
         <SiKakaotalk className="mr-2 bg-black text-yellow-500" size="2em" />
         Kakao 로그인

--- a/src/app/(non-auth)/signup/page.tsx
+++ b/src/app/(non-auth)/signup/page.tsx
@@ -31,7 +31,7 @@ const SignUpPage = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 pt-8">
       <div className="w-full max-w-md p-8 bg-white shadow-lg rounded-2xl">
         <div className="flex items-center justify-center w-24 h-24 mx-auto mb-4 bg-black rounded-full">
           {/* 여기에 고양이 */}

--- a/src/app/(non-auth)/terms/page.tsx
+++ b/src/app/(non-auth)/terms/page.tsx
@@ -40,9 +40,8 @@ const TermsPage = () => {
         }
     };
     
-
     return (
-        <div className="flex items-center justify-center">
+        <div className="flex items-center justify-center pt-16">
         <div className="bg-white p-3 rounded shadow max-w-md w-full mx-4">
           <h1 className="text-xl font-semibold text-center mt-4 mb-6">약관 동의</h1>
           <form className="space-y-6 mb-10" onSubmit={handleSubmit}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ const Home = () => {
   if (error) return <div>An error occurred: {error instanceof Error ? error.message : 'Unknown error'}</div>;
 
   return (
-    <div className="flex flex-col items-center justify-center">
+    <div className="flex flex-col items-center justify-center pt-16">
       <h1>User Profile</h1>
       {profile ? (
         <div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
-'use client';
+"use client"
 
+import { useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import Link from 'next/link';
 import { toast } from 'react-toastify';
@@ -7,10 +8,44 @@ import { GiHamburgerMenu } from 'react-icons/gi';
 import MenuPage from '@/app/menu/page';
 import { useAtom } from 'jotai';
 import { isMenuOpenAtom } from '../../store/store';
+import { isLoggedInAtom } from '../../store/store';
+import { supabase } from '@/utils/supabase/supabase';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useAtom(isMenuOpenAtom);
+  const [isLoggedIn, setIsLoggedIn] = useAtom(isLoggedInAtom); 
   const { logout } = useAuth();
+
+  useEffect(() => {
+    const handleAuthStateChange = (event: any, session: any) => {
+      if (event === 'SIGNED_IN') {
+        setIsLoggedIn(true); 
+      } else if (event === 'SIGNED_OUT') {
+        setIsLoggedIn(false); 
+      }
+    };
+
+    const subscription = supabase.auth.onAuthStateChange(handleAuthStateChange);
+
+    const checkAndUpdateAuthState = async () => {
+      const { data, error } = await supabase.auth.getUser();
+
+      if (error) {
+      } else {
+        if (data) {
+          setIsLoggedIn(true);
+        } else {
+          setIsLoggedIn(false);
+        }
+      }
+    };
+
+    checkAndUpdateAuthState();
+
+    return () => {
+      subscription.data.subscription.unsubscribe();
+    };
+  }, [setIsLoggedIn]); 
 
   const handleLogout = async () => {
     await logout();
@@ -30,9 +65,17 @@ const Header = () => {
         <Link href="/" className="text-pointColor1 font-bold">
           로고ㅎ
         </Link>
-        <button onClick={handleLogout} className="ml-10">
-          로그아웃
-        </button>
+        {isLoggedIn ? ( 
+          <button onClick={handleLogout} className="ml-10">
+            로그아웃
+          </button>
+        ) : (
+          <Link href="/login"> 
+            <button className="ml-10">
+              로그인
+            </button>
+          </Link>
+        )}
       </section>
 
       {isMenuOpen && (

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -175,7 +175,6 @@ export const useAuth = () => {
     setLoading(true);
 
     const { data: userData, error: getUserError } = await supabase.auth.getUser();
-    console.log('data', userData); 
     if (getUserError || !userData.user) {
       setError(getUserError?.message || "로그인한 사용자가 없습니다.");
       setLoading(false);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,3 +1,6 @@
 import { atom } from 'jotai';
 
 export const isMenuOpenAtom = atom(false);
+
+export const isLoggedInAtom = atom(false);
+export const currentUserAtom = atom(null);


### PR DESCRIPTION
## 📍 관련 이슈

🔗https://coding-legend.atlassian.net/browse/MMEASY-164 

## ✍️ Task TODOLIST

- [x] 헤더 로그인 상태에 따라 조건부로 로그인, 로그아웃 렌더링 되게 하기
- [ ] 메뉴 자동 닫힘 구현하기
- [ ] 소셜 로그인 profile 관련 문제 알아보기

## 🚨 TroubleShotting

소셜 로그인이 아닌 일반 로그인시에는 로그인 로그아웃이 잘 렌더링 되었지만, 
소셜 로그인으로 로그인시 바뀌지 않는 문제가 발생해 알아본 결과 소셜 로그인은 다른 외부 페이지에서 로그인 하기 때문에 onAuthStateChange 메서드가 감지하지 못함. 따라서 getUser 메서드를 사용해 소셜 로그인 후 가져온 유저 정보를 바탕으로 렌더링 되게 해결