### PR TITLE
[style] question CSS, tailwind.config 에 backgroundSize 추가

### DIFF
--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import Image from 'next/image';
-import { Dispatch, useRef, useState } from 'react';
+import { Dispatch, useRef } from 'react';
 import { toast } from 'react-toastify';
 import { SetStateAction } from 'jotai';
+import checkboxImg from '@/assets/checkbox.png';
 
 import { type Option, type Question, QuestionType } from '@/types/quizzes';
 
@@ -14,10 +15,6 @@ const QuestionForm = ({
   questions: Question[];
   setQuestions: Dispatch<SetStateAction<Question[]>>;
 }) => {
-  const fileInputRef = useRef([]);
-  // const fileInputRef = useRef<HTMLInputElement>(null);
-  // const fileInput = document.getElementById(id)
-
   /** 문제 타입 바꾸기 버튼 핸들러 */
   const handleChangeType = (id: string | undefined, type: QuestionType) => {
     setQuestions((prev) =>
@@ -142,14 +139,14 @@ const QuestionForm = ({
   };
 
   return (
-    <article className="pb-12 flex flex-col place-items-center gap-12">
+    <main className="py-8 text-pointColor1">
       {questions.map((question) => {
         const { id, type, options, img_url } = question;
         return (
           /** 유형, 휴지통 섹션 */
-          <section key={id}>
-            <section className="flex justify-between">
-              <section className="w-[45vw]">
+          <article key={id} className="w-[570px] mx-auto pb-12 flex flex-col gap-4">
+            <section className="w-full flex justify-between text-md">
+              <section>
                 <label className="pr-4">
                   <input
                     type="radio"
@@ -158,7 +155,7 @@ const QuestionForm = ({
                     className="mr-2"
                     onChange={() => handleChangeType(id, QuestionType.objective)}
                   />
-                  객관식
+                  선택형
                 </label>
                 <label>
                   <input
@@ -167,18 +164,26 @@ const QuestionForm = ({
                     className="mr-2"
                     onChange={() => handleChangeType(id, QuestionType.subjective)}
                   />
-                  주관식
+                  주관형
                 </label>
               </section>
-              <button type="button" onClick={() => handleDeleteQuestion(id)}>
-                🗑️
+              <button type="button" className="text-xl" onClick={() => handleDeleteQuestion(id)}>
+                ✕
               </button>
             </section>
             {/* 이미지, input 섹션 */}
             <section>
               {type === QuestionType.objective ? (
                 <div className="flex flex-col place-items-center gap-4">
-                  <div className="w-40 h-40">
+                  <input
+                    type="text"
+                    className="w-full px-4 py-2 border-solid border border-pointColor1 rounded-md"
+                    placeholder="문제를 입력해 주세요. ex)Apple의 한국어 뜻으로 알맞은 것은?"
+                    onChange={(e) => {
+                      handleChangeTitle(id, e.target.value);
+                    }}
+                  />
+                  <div className="w-full h-40 border-solid border border-pointColor1 rounded-md">
                     <input
                       type="file"
                       id={`file-input-${id}`}
@@ -188,38 +193,30 @@ const QuestionForm = ({
                       }}
                       className="hidden"
                     />
-                    <label htmlFor={`file-input-${id}`}>
+                    <label htmlFor={`file-input-${id}`} className="">
                       <Image
                         src={img_url}
                         alt="문항 이미지"
-                        className="w-full h-full object-cover cursor-pointer"
-                        width={200}
-                        height={200}
+                        className="w-full h-full object-cover rounded-md cursor-pointer"
+                        width={570}
+                        height={160}
                       />
                     </label>
                   </div>
-                  <input
-                    type="text"
-                    className="w-[500px] px-4 py-2 font-bold border-solid border border-pointColor1"
-                    placeholder="문제를 입력해 주세요. ex)Apple의 한국어 뜻으로 알맞은 것은?"
-                    onChange={(e) => {
-                      handleChangeTitle(id, e.target.value);
-                    }}
-                  />
                   {options.map((option) => {
                     return (
-                      <div key={option.id} className="flex place-items-center gap-3">
+                      <div key={option.id} className="w-full flex place-items-center justify-between">
                         <input
                           type="checkbox"
-                          className="w-[42px] h-[42px]"
                           checked={option.isAnswer}
+                          className="w-11 h-11 appearance-none border-solid border border-pointColor1 rounded-md checked:bg-pointColor1 checked:bg-[url('https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/assets/checkbox.png')] bg-md bg-no-repeat bg-center"
                           onChange={() => {
                             handleCheckObjectAnswer(id, options, option.id);
                           }}
                         />
                         <input
                           type="text"
-                          className="w-[500px] px-4 py-2 border-solid border border-pointColor1"
+                          className="w-4/5 px-4 py-[9px] border-solid border border-pointColor1 rounded-md"
                           placeholder="선택지를 입력해 주세요."
                           onChange={(e) => {
                             e.preventDefault();
@@ -228,16 +225,20 @@ const QuestionForm = ({
                         />
                         <button
                           type="button"
-                          className="w-[42px] h-[42px] text-2xl text-white bg-pointColor1"
+                          className="w-11 h-11 text-2xl text-pointColor1 bg-white border-solid border border-pointColor1 rounded-md"
                           onClick={() => handleDeleteOption(id, options, option.id)}
                         >
-                          -
+                          ✕
                         </button>
                       </div>
                     );
                   })}
-                  <button type="button" onClick={() => handleAddOption(id, options)}>
-                    ➕
+                  <button
+                    type="button"
+                    className="w-full pb-[6px] text-3xl border-solid border border-pointColor1 rounded-md"
+                    onClick={() => handleAddOption(id, options)}
+                  >
+                    +
                   </button>
                 </div>
               ) : (
@@ -264,7 +265,7 @@ const QuestionForm = ({
                   </div>
                   <input
                     type="text"
-                    className="w-[500px] px-4 py-2 font-bold border-solid border border-pointColor1"
+                    className="w-[500px] px-4 py-2 border-solid border border-pointColor1"
                     placeholder="문제를 입력해 주세요. ex)Apple의 한국어 뜻으로 알맞은 것은?"
                     onChange={(e) => {
                       e.preventDefault();
@@ -283,10 +284,10 @@ const QuestionForm = ({
                 </div>
               )}
             </section>
-          </section>
+          </article>
         );
       })}
-    </article>
+    </main>
   );
 };
 

--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -44,7 +44,7 @@ const QuizForm = () => {
           isAnswer: false
         }
       ],
-      img_url: 'https://via.placeholder.com/200x200',
+      img_url: 'https://via.placeholder.com/570x160',
       correct_answer: ''
     },
     {
@@ -63,7 +63,7 @@ const QuizForm = () => {
           isAnswer: false
         }
       ],
-      img_url: 'https://via.placeholder.com/200x200',
+      img_url: 'https://via.placeholder.com/570x160',
       correct_answer: ''
     }
   ]);
@@ -217,10 +217,7 @@ const QuizForm = () => {
             <BlueTextArea value={info} onChange={(e) => setInfo(e.target.value)} />
           </div>
         </div>
-
-        <div className="flex flex-col">
-          <QuestionForm questions={questions} setQuestions={setQuestions} />
-        </div>
+        <QuestionForm questions={questions} setQuestions={setQuestions} />
         <PlusQuestionBtn onClick={handleAddQuestion} />
         <div className="bg-bgColor1 flex items-center justify-center pt-10 pb-9 gap-5 border-solid border-t border-pointColor1">
           <CancelButton text="취소하기" onClick={handleCancelBtn} width="w-64" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,7 +19,8 @@ const config: Config = {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))'
       }
-    }
+    },
+    backgroundSize: { md: '80%' }
   },
   plugins: []
 };


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-161

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] question CSS 마무리
- [x] supabase storage 에 assets 폴더 추가
- [x] tailwind.config 에 backgroundSize md : 80% 로 추가

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- 체크박스 커스텀하다가 checked:bg-[url('**여기**')] 부분에 파일 경로를 넣어야 하는데,
절대.. 안들어가서 supabase 로 이미지 링크 넣어놨습니다. 로컬에 만들었던 assets 폴더는 우선 지웠습니다.
- 체크박스 배경색은 pointColor1 로 넣었고, 그 위에 화이트 체크표시.png 들어갔습니다.
- 체크표시 사이즈 bg-md 로 조절했습니다.
- appearance-none 이 원래 체크박스 디자인 없애줍니다!

QustionForm.tsx
```tsx
<input
  type="checkbox"
  checked={option.isAnswer}
  className="w-11 h-11 appearance-none border-solid border border-pointColor1 rounded-md checked:bg-pointColor1 
    checked:bg-[url('https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/assets/checkbox.png')]
    bg-md bg-no-repeat bg-center"
  onChange={() => {
    handleCheckObjectAnswer(id, options, option.id);
  }}
/>
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
<img width="1026" alt="스크린샷 2024-04-04 오후 5 38 25" src="https://github.com/mm-easy/mm-easy/assets/142870577/054abdd0-a87a-4169-9b51-b327bbf8ec29">
<img width="172" alt="스크린샷 2024-04-04 오후 5 33 04" src="https://github.com/mm-easy/mm-easy/assets/142870577/07b74f2e-f07a-4db7-be43-b7e7d28c62e3">


## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
- supabase assets 폴더 추가했는데 여기서 계속 가져와도 좋을 거 같습니다..
﻿
![스크린샷 2024-04-04 오후 5 37 02](https://github.com/mm-easy/mm-easy/assets/142870577/f775d686-d222-453d-bf60-0b050f09ab07)
![스크린샷 2024-04-04 오후 5 37 06](https://github.com/mm-easy/mm-easy/assets/142870577/ddd371d8-63b8-4937-a352-5c15c171f731)

- tailwind.config 에 이 부분 지워도 될 거 같아요..?
```ts
 backgroundImage: {
  'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
  'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))'
}
```