### PR TITLE
[feat] question 내 중복 태그들 컴포넌트로 분리

### DIFF
--- a/src/app/(quiz)/(components)/InputQuestionImg.tsx
+++ b/src/app/(quiz)/(components)/InputQuestionImg.tsx
@@ -1,0 +1,36 @@
+import Image from 'next/image';
+
+const InputQuestionImg = ({
+  id,
+  img_url,
+  onChange
+}: {
+  id: string | undefined;
+  img_url: string;
+  onChange: (id: string | undefined, files: FileList | null) => void;
+}) => {
+  return (
+    <div className="w-full h-40 border-solid border border-pointColor1 rounded-md">
+      <input
+        type="file"
+        id={`file-input-${id}`}
+        onChange={(e) => {
+          e.preventDefault();
+          onChange(id, e.target.files);
+        }}
+        className="hidden"
+      />
+      <label htmlFor={`file-input-${id}`} className="">
+        <Image
+          src={img_url}
+          alt="문항 이미지"
+          className="w-full h-full object-cover rounded-md cursor-pointer"
+          width={570}
+          height={160}
+        />
+      </label>
+    </div>
+  );
+};
+
+export default InputQuestionImg;

--- a/src/app/(quiz)/(components)/InputQuestionTitle.tsx
+++ b/src/app/(quiz)/(components)/InputQuestionTitle.tsx
@@ -1,0 +1,20 @@
+const InputQuestionTitle = ({
+  id,
+  onChange
+}: {
+  id: string | undefined;
+  onChange: (id: string | undefined, title: string) => void;
+}) => {
+  return (
+    <input
+      type="text"
+      className="w-full px-4 py-2 border-solid border border-pointColor1 rounded-md"
+      placeholder="문제를 입력해 주세요. ex)Apple의 한국어 뜻으로 알맞은 것은?"
+      onChange={(e) => {
+        onChange(id, e.target.value);
+      }}
+    />
+  );
+};
+
+export default InputQuestionTitle;

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -219,7 +219,7 @@ const QuestionForm = ({
                   <InputQuestionImg id={id} img_url={img_url} onChange={handleChangeImg} />
                   <input
                     type="text"
-                    className="w-[500px] px-4 py-2 border-solid border border-pointColor1"
+                    className="w-full px-4 py-2 border-solid border border-pointColor1 rounded-md"
                     placeholder="정답을 입력해 주세요."
                     onChange={(e) => {
                       e.preventDefault();

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -8,6 +8,7 @@ import checkboxImg from '@/assets/checkbox.png';
 
 import { type Option, type Question, QuestionType } from '@/types/quizzes';
 import SelectQuestionType from './SelectQuestionType';
+import InputQuestionTitle from './InputQuestionTitle';
 
 const QuestionForm = ({
   questions,
@@ -171,14 +172,7 @@ const QuestionForm = ({
             <section>
               {type === QuestionType.objective ? (
                 <div className="flex flex-col place-items-center gap-4">
-                  <input
-                    type="text"
-                    className="w-full px-4 py-2 border-solid border border-pointColor1 rounded-md"
-                    placeholder="문제를 입력해 주세요. ex)Apple의 한국어 뜻으로 알맞은 것은?"
-                    onChange={(e) => {
-                      handleChangeTitle(id, e.target.value);
-                    }}
-                  />
+                  <InputQuestionTitle id={id} onChange={handleChangeTitle} />
                   <div className="w-full h-40 border-solid border border-pointColor1 rounded-md">
                     <input
                       type="file"
@@ -239,7 +233,8 @@ const QuestionForm = ({
                 </div>
               ) : (
                 <div className="flex flex-col place-items-center gap-4">
-                  <div className="w-40 h-40">
+                  <InputQuestionTitle id={id} onChange={handleChangeTitle} />
+                  <div className="w-full h-40">
                     <input
                       type="file"
                       id={`fileInput${id}`}
@@ -259,15 +254,7 @@ const QuestionForm = ({
                       />
                     </label>
                   </div>
-                  <input
-                    type="text"
-                    className="w-[500px] px-4 py-2 border-solid border border-pointColor1"
-                    placeholder="문제를 입력해 주세요. ex)Apple의 한국어 뜻으로 알맞은 것은?"
-                    onChange={(e) => {
-                      e.preventDefault();
-                      handleChangeTitle(id, e.target.value);
-                    }}
-                  />
+
                   <input
                     type="text"
                     className="w-[500px] px-4 py-2 border-solid border border-pointColor1"

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -9,6 +9,7 @@ import checkboxImg from '@/assets/checkbox.png';
 import { type Option, type Question, QuestionType } from '@/types/quizzes';
 import SelectQuestionType from './SelectQuestionType';
 import InputQuestionTitle from './InputQuestionTitle';
+import InputQuestionImg from './InputQuestionImg';
 
 const QuestionForm = ({
   questions,
@@ -173,26 +174,7 @@ const QuestionForm = ({
               {type === QuestionType.objective ? (
                 <div className="flex flex-col place-items-center gap-4">
                   <InputQuestionTitle id={id} onChange={handleChangeTitle} />
-                  <div className="w-full h-40 border-solid border border-pointColor1 rounded-md">
-                    <input
-                      type="file"
-                      id={`file-input-${id}`}
-                      onChange={(e) => {
-                        e.preventDefault();
-                        handleChangeImg(id, e.target.files);
-                      }}
-                      className="hidden"
-                    />
-                    <label htmlFor={`file-input-${id}`} className="">
-                      <Image
-                        src={img_url}
-                        alt="문항 이미지"
-                        className="w-full h-full object-cover rounded-md cursor-pointer"
-                        width={570}
-                        height={160}
-                      />
-                    </label>
-                  </div>
+                  <InputQuestionImg id={id} img_url={img_url} onChange={handleChangeImg} />
                   {options.map((option) => {
                     return (
                       <div key={option.id} className="w-full flex place-items-center justify-between">
@@ -234,27 +216,7 @@ const QuestionForm = ({
               ) : (
                 <div className="flex flex-col place-items-center gap-4">
                   <InputQuestionTitle id={id} onChange={handleChangeTitle} />
-                  <div className="w-full h-40">
-                    <input
-                      type="file"
-                      id={`fileInput${id}`}
-                      onChange={(e) => {
-                        e.preventDefault();
-                        handleChangeImg(id, e.target.files);
-                      }}
-                      className="hidden"
-                    />
-                    <label htmlFor={`file-input-${id}`} className="cursor-pointer">
-                      <Image
-                        src={img_url}
-                        alt="문항 이미지"
-                        className="w-full h-full object-cover cursor-pointer"
-                        width={200}
-                        height={200}
-                      />
-                    </label>
-                  </div>
-
+                  <InputQuestionImg id={id} img_url={img_url} onChange={handleChangeImg} />
                   <input
                     type="text"
                     className="w-[500px] px-4 py-2 border-solid border border-pointColor1"

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -7,6 +7,7 @@ import { SetStateAction } from 'jotai';
 import checkboxImg from '@/assets/checkbox.png';
 
 import { type Option, type Question, QuestionType } from '@/types/quizzes';
+import SelectQuestionType from './SelectQuestionType';
 
 const QuestionForm = ({
   questions,
@@ -147,25 +148,20 @@ const QuestionForm = ({
           <article key={id} className="w-[570px] mx-auto pb-12 flex flex-col gap-4">
             <section className="w-full flex justify-between text-md">
               <section>
-                <label className="pr-4">
-                  <input
-                    type="radio"
-                    name={id}
-                    defaultChecked
-                    className="mr-2"
-                    onChange={() => handleChangeType(id, QuestionType.objective)}
-                  />
-                  선택형
-                </label>
-                <label>
-                  <input
-                    type="radio"
-                    name={id}
-                    className="mr-2"
-                    onChange={() => handleChangeType(id, QuestionType.subjective)}
-                  />
-                  주관형
-                </label>
+                <SelectQuestionType
+                  id={id}
+                  defaultChecked={true}
+                  onChange={handleChangeType}
+                  type={QuestionType.objective}
+                  title="선택형"
+                />
+                <SelectQuestionType
+                  id={id}
+                  defaultChecked={false}
+                  onChange={handleChangeType}
+                  type={QuestionType.subjective}
+                  title="주관형"
+                />
               </section>
               <button type="button" className="text-xl" onClick={() => handleDeleteQuestion(id)}>
                 ✕

--- a/src/app/(quiz)/(components)/SelectQuestionType.tsx
+++ b/src/app/(quiz)/(components)/SelectQuestionType.tsx
@@ -1,5 +1,4 @@
 import { QuestionType } from '@/types/quizzes';
-import { ReactNode } from 'react';
 
 const SelectQuestionType = ({
   id,

--- a/src/app/(quiz)/(components)/SelectQuestionType.tsx
+++ b/src/app/(quiz)/(components)/SelectQuestionType.tsx
@@ -1,0 +1,31 @@
+import { QuestionType } from '@/types/quizzes';
+import { ReactNode } from 'react';
+
+const SelectQuestionType = ({
+  id,
+  defaultChecked,
+  onChange,
+  type,
+  title
+}: {
+  id: string | undefined;
+  defaultChecked: boolean;
+  onChange: (id: string | undefined, type: QuestionType) => void;
+  type: QuestionType;
+  title: string;
+}) => {
+  return (
+    <label className="pr-4">
+      <input
+        type="radio"
+        name={id}
+        defaultChecked={defaultChecked}
+        className="mr-2"
+        onChange={() => onChange(id, type)}
+      />
+      {title}
+    </label>
+  );
+};
+
+export default SelectQuestionType;

--- a/src/app/(quiz)/quiz-try/page.tsx
+++ b/src/app/(quiz)/quiz-try/page.tsx
@@ -1,5 +1,11 @@
+import SubHeader from '@/components/common/SubHeader';
+
 const QuizTryPage = () => {
-  return <div>QuizTryPage</div>;
+  return (
+    <>
+      <SubHeader text="퀴즈 풀기" />
+    </>
+  );
 };
 
 export default QuizTryPage;

--- a/src/components/common/SubHeader.tsx
+++ b/src/components/common/SubHeader.tsx
@@ -4,7 +4,7 @@ interface QuizFormHeaderProps {
 
 const SubHeader: React.FC<QuizFormHeaderProps> = ({ text }) => {
   return (
-    <main className="pt-20 p-4 pl-10 bg-bgColor1 border-b-2 border-pointColor1 text-pointColor1 flex items-end">
+    <main className="pt-20 p-4 pl-10 bg-bgColor1 border-b border-pointColor1 text-pointColor1 flex items-end">
       {text}
     </main>
   );


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-167

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] question 내에서 중복되는 type input, title input, img input 컴포넌트 분리
- [x] 주관형 CSS 마무리
- [x] SubHeader 보더 1px 로 줄였습니다!

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- 선택형, 주관형 부분을 공통 컴포넌트로 묶었는데,
내려주는 값이 많아서 분리하는게 맞는지 고민입니다..

QustionForm.tsx
- 분리 전
```tsx
<label className="pr-4">
    <input
    type="radio"
    name={id}
    defaultChecked
    className="mr-2"
    onChange={() => handleChangeType(id, QuestionType.objective)}
  />
  선택형
</label>
<label>
  <input
    type="radio"
    name={id}
    className="mr-2"
    onChange={() => handleChangeType(id, QuestionType.subjective)}
  />
  주관형
</label>
```
- 분리 후
```tsx
<SelectQuestionType
  id={id}
  defaultChecked={true}
  onChange={handleChangeType}
  type={QuestionType.objective}
  title="선택형"
/>
<SelectQuestionType
  id={id}
  defaultChecked={false}
  onChange={handleChangeType}
  type={QuestionType.subjective}
  title="주관형"
/>
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
<img width="853" alt="스크린샷 2024-04-04 오후 9 26 25" src="https://github.com/mm-easy/mm-easy/assets/142870577/7f81a043-b65c-498e-b6f4-229d87cd973b">