### PR TITLE
[feat] quiz-form 페이지 퀴즈 등록하기 버튼 완료

### DIFF
--- a/src/api/quizzes.ts
+++ b/src/api/quizzes.ts
@@ -1,22 +1,40 @@
-import { Option, Question, Quiz } from '@/types/quizzes';
+import { Option, OptionsToInsert, Question, QuestionsToInsert, Quiz } from '@/types/quizzes';
 import { supabase } from '@/utils/supabase/supabase';
 
+/** quiz 썸네일을 스토리지에 upload */
 export const uploadThumbnailToStorage = async (file: File, fileName: string) => {
   try {
     const { data, error } = await supabase.storage.from('quiz-thumbnails').upload(fileName, file, {
       contentType: file.type
     });
     if (error) {
-      alert(`일시적인 오류가 발생했습니다. 다시 시도하세요.`);
+      alert('썸네일 업로드 중 오류가 발생했습니다. 다시 시도하세요.');
       throw error;
     }
     return data.path;
   } catch (error) {
-    alert(`일시적인 오류가 발생했습니다. 다시 시도하세요.`);
+    console.error('퀴즈 썸네일 이미지 업로드 에러 발생', error);
     return null;
   }
 };
 
+/** question 첨부 이미지를 스토리지에 upload */
+export const uploadImageToStorage = async (imgFile: File | null, fileName: string) => {
+  try {
+    if (!imgFile) return;
+    const { data, error } = await supabase.storage.from('question-imgs').upload(fileName, imgFile);
+    if (error) {
+      alert('이미지 업로드 중 오류가 발생했습니다. 다시 시도하세요.');
+      throw error;
+    }
+    return data;
+  } catch (error) {
+    console.error('문제 이미지 업로드 에러 발생', error);
+    return null;
+  }
+};
+
+/** quiz를 quizzes 테이블에 insert */
 export const insertQuizToTable = async (newQuiz: Quiz) => {
   try {
     const { data, error } = await supabase.from('quizzes').insert([newQuiz]).select('*');
@@ -24,7 +42,6 @@ export const insertQuizToTable = async (newQuiz: Quiz) => {
       throw error;
     }
     const quizId = data?.[0].id;
-    console.log('등록완료', quizId);
     return quizId;
   } catch (error) {
     console.error('게시글 등록 실패', error);
@@ -33,17 +50,14 @@ export const insertQuizToTable = async (newQuiz: Quiz) => {
   }
 };
 
-export const insertQuestionsToTable = async (newQuestions: Question[]) => {
+/** questions를 questions 테이블에 insert */
+export const insertQuestionsToTable = async (newQuestions: QuestionsToInsert) => {
   try {
-    const insertPromises = newQuestions.map(async (question) => {
-      const { data, error } = await supabase.from('questions').insert([question]).select('*');
-      if (error) {
-        throw error;
-      }
-      return data;
-    });
-    const insertResults = await Promise.all(insertPromises);
-    return insertResults;
+    const { data, error } = await supabase.from('questions').insert([newQuestions]).select('*');
+    if (error) {
+      throw error;
+    }
+    return data;
   } catch (error) {
     console.error('문제 등록 실패', error);
     alert('일시적인 오류 발생');
@@ -51,7 +65,8 @@ export const insertQuestionsToTable = async (newQuestions: Question[]) => {
   }
 };
 
-export const insertOptionsToTable = async (newOptions: Option[]) => {
+/** options를 question_options 테이블에 insert*/
+export const insertOptionsToTable = async (newOptions: OptionsToInsert[]) => {
   try {
     const insertPromises = newOptions.map(async (option) => {
       const { data, error } = await supabase.from('question_options').insert([option]).select('*');

--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -6,6 +6,7 @@ import { toast } from 'react-toastify';
 import { SetStateAction } from 'jotai';
 
 import { type Option, type Question, QuestionType } from '@/types/quizzes';
+import { generateImgFileName } from '@/utils/generateFileName';
 
 const QuestionForm = ({
   questions,
@@ -42,7 +43,7 @@ const QuestionForm = ({
       const newOption = {
         id: crypto.randomUUID(),
         content: '',
-        isAnswer: false
+        is_answer: false
       };
       setQuestions((prev) =>
         prev.map((question) => {
@@ -98,7 +99,7 @@ const QuestionForm = ({
           ? {
               ...question,
               options: options.map((option) => {
-                return option.id === optionId ? { ...option, isAnswer: true } : { ...option, isAnswer: false };
+                return option.id === optionId ? { ...option, is_answer: true } : { ...option, is_answer: false };
               })
             }
           : question;
@@ -107,10 +108,10 @@ const QuestionForm = ({
   };
 
   /** 주관식 정답 입력 핸들러 */
-  const handleChangeCorrectAnswer = (id: string | undefined, correctAnswer: string) => {
+  const handleChangeCorrectAnswer = (id: string | undefined, correct_answer: string) => {
     setQuestions((prev) =>
       prev.map((question) => {
-        return question.id === id ? { ...question, correctAnswer } : question;
+        return question.id === id ? { ...question, correct_answer } : question;
       })
     );
   };
@@ -122,7 +123,7 @@ const QuestionForm = ({
       const img_url = URL.createObjectURL(file);
       setQuestions((prev) =>
         prev.map((question) => {
-          return question.id === id ? { ...question, img_url } : question;
+          return question.id === id ? { ...question, img_url, img_file: file } : question;
         })
       );
     }
@@ -212,7 +213,7 @@ const QuestionForm = ({
                         <input
                           type="checkbox"
                           className="w-[42px] h-[42px]"
-                          checked={option.isAnswer}
+                          checked={option.is_answer}
                           onChange={() => {
                             handleCheckObjectAnswer(id, options, option.id);
                           }}

--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -215,6 +215,7 @@ const QuizForm = () => {
           question_id: insertQuestionResult
         }));
         await insertOptionsMutation.mutateAsync(newOptions);
+        router.replace('/quiz-list');
       });
     } catch (error) {
       console.log('퀴즈 생성 중 에러 발생');

--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -4,17 +4,17 @@ import QuestionForm from './QuestionForm';
 import Image from 'next/image';
 import PlusQuestionBtn from './PlusQuestionBtn';
 import PageUpBtn from '@/components/common/PageUpBtn';
-import useSubmitQuiz from '../mutations';
 
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
-import { uploadThumbnailToStorage } from '@/api/quizzes';
-import { generateFileName } from '@/utils/generateFileName';
-
-import { QuestionType, type Question, type Quiz } from '@/types/quizzes';
 import { BlueInput, BlueLevelSelect, BlueTextArea } from '@/components/common/BlueInput';
 import { CancelButton, SubmitButton } from '@/components/common/FormButtons';
+import { generateFileName, generateImgFileName } from '@/utils/generateFileName';
+import { uploadImageToStorage, uploadThumbnailToStorage } from '@/api/quizzes';
+import { useSubmitOptions, useSubmitQuestions, useSubmitQuiz } from '../mutations';
+
+import { QuestionType, type Question, type Quiz, QuestionsToInsert } from '@/types/quizzes';
 
 const QuizForm = () => {
   const [scrollPosition, setScrollPosition] = useState<number>(0);
@@ -26,6 +26,8 @@ const QuizForm = () => {
 
   /** 퀴즈 등록 mutation */
   const insertQuizMutation = useSubmitQuiz();
+  const insertQuestionsMutation = useSubmitQuestions();
+  const insertOptionsMutation = useSubmitOptions();
 
   const [questions, setQuestions] = useState<Question[]>([
     {
@@ -36,14 +38,15 @@ const QuizForm = () => {
         {
           id: crypto.randomUUID(),
           content: '',
-          isAnswer: false
+          is_answer: false
         },
         {
           id: crypto.randomUUID(),
           content: '',
-          isAnswer: false
+          is_answer: false
         }
       ],
+      img_file: null,
       img_url: 'https://via.placeholder.com/200x200',
       correct_answer: ''
     },
@@ -55,21 +58,19 @@ const QuizForm = () => {
         {
           id: crypto.randomUUID(),
           content: '',
-          isAnswer: false
+          is_answer: false
         },
         {
           id: crypto.randomUUID(),
           content: '',
-          isAnswer: false
+          is_answer: false
         }
       ],
+      img_file: null,
       img_url: 'https://via.placeholder.com/200x200',
       correct_answer: ''
     }
   ]);
-
-  console.log('1', questions[0]);
-  console.log('2', questions[1]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
@@ -123,14 +124,15 @@ const QuizForm = () => {
             {
               id: crypto.randomUUID(),
               content: '',
-              isAnswer: false
+              is_answer: false
             },
             {
               id: crypto.randomUUID(),
               content: '',
-              isAnswer: false
+              is_answer: false
             }
           ],
+          img_file: null,
           img_url: 'https://via.placeholder.com/200x200',
           correct_answer: ''
         }
@@ -143,8 +145,7 @@ const QuizForm = () => {
 
   /** 등록 버튼 클릭 핸들러 */
   const handleSubmitBtn = async () => {
-    console.log('입력된 값들', questions);
-
+    console.log('끼히히히', questions);
     if (!level) {
       alert('난이도를 선택해주세요.');
       return;
@@ -154,6 +155,7 @@ const QuizForm = () => {
       return;
     }
 
+    // 퀴즈 썸네일 이미지를 스토리지에 업로드
     try {
       let imgUrl = null;
       if (file) {
@@ -162,6 +164,29 @@ const QuizForm = () => {
         console.log('스토리지에 이미지 업로드 성공', imgUrl);
       }
 
+      // 문제에 첨부된 이미지들을 스토리지에 업로드
+      try {
+        const imgFileData = questions.map((question) => ({
+          id: question.id,
+          img_file: question.img_file
+        }));
+        for (const data of imgFileData) {
+          if (data.img_file) {
+            const formattedName = generateImgFileName(data.img_file, data.id);
+            const uploadResult = await uploadImageToStorage(data.img_file, formattedName);
+            if (uploadResult) {
+              console.log('이미지들 업로드 성공!', uploadResult);
+            } else {
+              console.error('이미지들 업로드 실패');
+            }
+          }
+        }
+      } catch (error) {
+        alert('일시적인 오류로 이미지 업로드에 실패했습니다. 다시 시도하세요.');
+        console.error;
+      }
+
+      // newQuiz 구성하여 quizzes 테이블에 인서트
       const newQuiz = {
         creator_id: 'cocoa@naver.com',
         level,
@@ -169,23 +194,36 @@ const QuizForm = () => {
         info,
         thumbnail_img_url: imgUrl || 'https://via.placeholder.com/200x200'
       };
-      const newQuestions = questions.map((item) => item);
 
-      insertQuizMutation.mutate({ newQuiz, newQuestions });
+      const insertQuizResult = await insertQuizMutation.mutateAsync(newQuiz);
+
+      // TRY 1.
+      // TODO: promise.all 로 비동기 병렬 처리하기.
+      questions.forEach(async (question) => {
+        const newQuestion = {
+          quiz_id: insertQuizResult as string,
+          title: question.title,
+          question_type: question.type,
+          correct_answer: question.correct_answer
+        };
+
+        // DB에 업로드된 리얼 question
+        const insertQuestionResult = await insertQuestionsMutation.mutateAsync(newQuestion);
+        const newOptions = question.options.map((option) => ({
+          content: option.content,
+          is_answer: option.is_answer,
+          question_id: insertQuestionResult
+        }));
+        await insertOptionsMutation.mutateAsync(newOptions);
+      });
     } catch (error) {
-      console.log('스토리지에 이미지 업로드 중 에러 발생');
+      console.log('퀴즈 생성 중 에러 발생');
     }
   };
 
   return (
     <main className="bg-blue-50 flex gap-5 flex-col justify-center items-center pb-16">
-      <form
-        className="flex flex-col min-w-full"
-        onSubmit={(e) => {
-          e.preventDefault();
-          handleSubmitBtn();
-        }}
-      >
+      <form className="flex flex-col min-w-full" onSubmit={(e) => e.preventDefault()}>
         <div className="p-10 flex flex-col gap-4 bg-bgColor1 justify-center items-center border-solid border-b border-pointColor1">
           <div className="flex gap-10">
             <div

--- a/src/app/(quiz)/(components)/QuizList.tsx
+++ b/src/app/(quiz)/(components)/QuizList.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 const QuizList = () => {
   return (
-    <main className="pt-64 p-5 flex flex-col gap-4 items-center">
+    <main className="p-5 flex flex-col gap-4 items-center">
       <div className="flex gap-5 flex-wrap mt-5">
         <div className="flex flex-col gap-3">
           <div className="border-solid border border-pointColor1 rounded-md overflow-hidden">

--- a/src/app/(quiz)/(components)/SelectQuizLevel.tsx
+++ b/src/app/(quiz)/(components)/SelectQuizLevel.tsx
@@ -1,8 +1,19 @@
+'use client';
+
+import { BlueButton, CancelButton } from '@/components/common/FormButtons';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 const SelectQuizLevel = () => {
+  const router = useRouter();
+  const handleMakeQuizBtn = () => {
+    router.push('/quiz-form');
+  };
   return (
-    <main className="fixed w-full bg-pointColor1 border-b border-pointColor1 flex justify-center">
+    <main className="w-full bg-pointColor1 border-b border-pointColor1 flex flex-col justify-center items-center">
+      <div className="mt-5 mr-1/4 ml-auto">
+        <BlueButton text="퀴즈 만들기" onClick={handleMakeQuizBtn} width="w-36" />
+      </div>
       <div className="flex items-end gap-1 overflow-hidden">
         <Image
           src="https://via.placeholder.com/350x240"

--- a/src/app/(quiz)/mutations.tsx
+++ b/src/app/(quiz)/mutations.tsx
@@ -1,37 +1,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 
-import type { Question, Quiz } from '@/types/quizzes';
-import { insertQuestionsToTable, insertQuizToTable } from '@/api/quizzes';
+import type { OptionsToInsert, Question, QuestionsToInsert, Quiz } from '@/types/quizzes';
+import { insertOptionsToTable, insertQuestionsToTable, insertQuizToTable } from '@/api/quizzes';
 
+/** quiz를 quizzes 테이블에 insert */
 export const useSubmitQuiz = () => {
   const queryClient = useQueryClient();
 
   const insertQuizMutation = useMutation({
-    mutationFn: async ({ newQuiz, newQuestions }: { newQuiz: Quiz; newQuestions: Question[] }) => {
+    mutationFn: async (newQuiz: Quiz) => {
       try {
         const result = await insertQuizToTable(newQuiz);
-        console.log('의의', result);
+        return result;
       } catch (error) {
         console.error('퀴즈 등록 실패', error);
         throw error;
       }
-
-      try {
-        const result = await insertQuestionsToTable(newQuestions);
-        console.log('의의', result);
-      } catch (error) {
-        console.error('퀴즈 등록 실패', error);
-        throw error;
-      }
-
-      // try {
-      //   const result = await insertQuizToTable(newQuiz);
-      //   console.log('의의', result);
-      // } catch (error) {
-      //   console.error('퀴즈 등록 실패', error);
-      //   throw error;
-      // }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['quizzes'] });
@@ -43,4 +28,48 @@ export const useSubmitQuiz = () => {
   return insertQuizMutation;
 };
 
-export default useSubmitQuiz;
+/** questions를 questions 테이블에 insert */
+export const useSubmitQuestions = () => {
+  const queryClient = useQueryClient();
+
+  const insertQuestionsMutation = useMutation({
+    mutationFn: async (newQuestions: QuestionsToInsert) => {
+      try {
+        const result = await insertQuestionsToTable(newQuestions);
+        const questionId = result[0]?.id;
+        return questionId;
+      } catch (error) {
+        console.error('문제들 등록 실패', error);
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['questions'] });
+    }
+  });
+
+  return insertQuestionsMutation;
+};
+
+/** options를 question_options 테이블에 insert */
+export const useSubmitOptions = () => {
+  const queryClient = useQueryClient();
+
+  const insertOptionsMutation = useMutation({
+    mutationFn: async (newOptions: OptionsToInsert[]) => {
+      try {
+        const result = await insertOptionsToTable(newOptions);
+        const optionIds = result.map((result) => result[0]?.id);
+        return optionIds;
+      } catch (error) {
+        console.error('객관식 선택지 등록 실패', error);
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['options'] });
+    }
+  });
+
+  return insertOptionsMutation;
+};

--- a/src/app/(quiz)/mutations.tsx
+++ b/src/app/(quiz)/mutations.tsx
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-
-import type { OptionsToInsert, Question, QuestionsToInsert, Quiz } from '@/types/quizzes';
 import { insertOptionsToTable, insertQuestionsToTable, insertQuizToTable } from '@/api/quizzes';
+
+import type { OptionsToInsert, QuestionsToInsert, Quiz } from '@/types/quizzes';
 
 /** quiz를 quizzes 테이블에 insert */
 export const useSubmitQuiz = () => {
@@ -20,8 +20,6 @@ export const useSubmitQuiz = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['quizzes'] });
-      toast.success('퀴즈가 등록되었습니다.');
-      // router.replace('/quiz-list');
     }
   });
 
@@ -68,6 +66,7 @@ export const useSubmitOptions = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['options'] });
+      toast.success('퀴즈가 등록되었습니다.');
     }
   });
 

--- a/src/components/common/FormButtons.tsx
+++ b/src/components/common/FormButtons.tsx
@@ -27,3 +27,15 @@ export const SubmitButton: React.FC<FormButtonProps> = ({ onClick, text, width }
     </button>
   );
 };
+
+export const BlueButton: React.FC<FormButtonProps> = ({ onClick, text, width }) => {
+  return (
+    <button
+      type="submit"
+      onClick={onClick}
+      className={`rounded-md text-white border-solid p-2 border border-white bg-pointColor1 ${width}`}
+    >
+      {text}
+    </button>
+  );
+};

--- a/src/types/quizzes.ts
+++ b/src/types/quizzes.ts
@@ -1,24 +1,3 @@
-export enum QuestionType {
-  objective = 'objective',
-  subjective = 'subjective'
-}
-
-export type Option = {
-  id: string;
-  content: string;
-  isAnswer: boolean;
-};
-
-export type Question = {
-  id?: string;
-  type: QuestionType;
-  title: string;
-  img_url: string;
-  correct_answer?: string;
-  options: Option[];
-  // options?: Option[];
-};
-
 export type Quiz = {
   id?: string;
   creator_id: string;
@@ -26,4 +5,34 @@ export type Quiz = {
   title: string;
   info: string;
   thumbnail_img_url: string | null;
+};
+
+export type Option = {
+  id: string;
+  content: string;
+  is_answer: boolean;
+};
+
+export type OptionsToInsert = Pick<Option, 'content' | 'is_answer'> & {
+  question_id: string;
+};
+
+export enum QuestionType {
+  objective = 'objective',
+  subjective = 'subjective'
+}
+
+export type Question = {
+  id?: string;
+  type: QuestionType;
+  title: string;
+  img_file: File | null;
+  img_url: string;
+  correct_answer: string;
+  options: Option[];
+};
+
+export type QuestionsToInsert = Pick<Question, 'title' | 'correct_answer'> & {
+  quiz_id: string;
+  question_type: QuestionType;
 };

--- a/src/utils/generateFileName.ts
+++ b/src/utils/generateFileName.ts
@@ -3,3 +3,8 @@ export const generateFileName = (file: File): string => {
   const extension = file.name.split('.').pop(); // 파일의 확장자
   return `${timestamp}.${extension}`;
 };
+
+export const generateImgFileName = (file: File, id: string | undefined): string => {
+  const extension = file.name.split('.').pop(); // 파일의 확장자
+  return `${id}.${extension}`;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,10 +14,6 @@ const config: Config = {
         pointColor1: '#2B84ED',
         pointColor2: '#FF8878',
         blackColor: '#2e2e2e'
-      },
-      backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))'
       }
     }
   },


### PR DESCRIPTION
## 📍 관련 이슈
🔗 https://coding-legend.atlassian.net/browse/MMEASY-120

## ✍️ Task TODOLIST
- [ ] 썸네일 이미지 첨부 시 이미지 storage/quiz-thumbnails 업로드
- [ ] 썸네일 이미지 첨부 안할 시 기본 이미지 url 사용
- [ ] table/quizzes에 퀴즈 인서트
- [ ] 문제에 첨부 이미지 있을 시 storage/question-imgs 업로드
- [ ] 문제에 첨부 이미지 없을 시 업로드 하지 않음
- [ ] table/questions에 문제들 인서트
- [ ] table/options에 선택지들 인서트
- [ ] 모든 작업 완료 후 toast.success 띄우고 quiz-list 페이지로 라우팅

## 🧑🏻‍💻 개발 내용
* api/quizzes.ts에 관련 supabase api들을 모아두었습니다.
* (quiz)/mutations.tsx에 관련 mutation들을 모아두었습니다.
* 등록 버튼 클릭 핸들러 코드가 무려 80줄....

## 🚨 TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요. -->
* 처음에는 questions(문제항목들)을 모두 한꺼번에 테이블에 올린 다음에 -> 
  자동생성된 question_id를 받아와서 -> 
  options(객관식선택지들)에 question_id를 넣어서 options 역시 한꺼번에 올리려고 했었습니다.
 그런데 이 자동생성된 questions_id들이 각각 어떤 선택지에 해당하는지 매치시키는 게 어려워서 방법을 바꾸었습니다.

* question과 그에 딸린 options(배열)를 한개씩 짝지어 올리는 방식으로 바꾸었습니다.
  question 하나가 올라가면서 자동생성된 하나의 question_id를 받아오고 ->
  해당 question_id와 함께 options 배열을 올렸습니다.

## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
mutations 꼭 분리해보세요!