### PR TITLE
[feat] react-quill 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/ssr": "^0.1.0",
     "@supabase/supabase-js": "^2.41.1",
     "@tanstack/react-query": "^5.28.9",
+    "dompurify": "^3.0.11",
     "jotai": "^2.7.1",
     "next": "14.1.4",
     "react": "^18",
@@ -23,6 +24,7 @@
     "react-toastify": "^10.0.5"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/(community)/(components)/CommunityForm.tsx
+++ b/src/app/(community)/(components)/CommunityForm.tsx
@@ -32,8 +32,8 @@ const CommunityForm = ({ selectedCategory }: CommunityFormProps) => {
     selectedCategory === '전체' ? posts : posts.filter((post) => post.category === selectedCategory);
 
   return (
-    <article className="flex w-full ,">
-      <div className="bg-white p-4 w-full">
+    <article className="flex w-full">
+      <div className="bg-white p-4 w-full ">
         <table className="w-full">
           <thead className="text-left">
             <tr className=" text-pointColor1 font-bold border-b-2 border-solid border-pointColor1">

--- a/src/app/(community)/(components)/NoticeEditor.tsx
+++ b/src/app/(community)/(components)/NoticeEditor.tsx
@@ -11,37 +11,40 @@ interface NoticeEditorProps {
 }
 
 const formats = [
-  'font',
-  'header',
-  'bold',
-  'italic',
-  'underline',
-  'strike',
-  'blockquote',
-  'list',
-  'bullet',
-  'indent',
-  'link',
-  'align',
-  'color',
-  'background',
-  'size',
-  'h1',
+  "header",
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "blockquote",
+  "list",
+  "bullet",
+  "indent",
+  "link",
+  "image",
+  "align",
+  "color",
+  "background",
 ];
 
 const NoticeEditor = ({ value, onChange }: NoticeEditorProps): ReactElement => {
-  const modules = useMemo(
-    () => ({
-      toolbar: [
-        [{ header: '1' }, { header: '2' }],
-        ['bold', 'italic', 'underline', 'strike'],
-        ['link', 'image']
-      ]
-    }),
-    []
-  );
+  const modules = {
+    toolbar: [
+      [{ header: [1, 2, false] }],
+      ["bold", "italic", "underline", "strike", "blockquote"],
+      [
+        { list: "ordered" },
+        { list: "bullet" },
+        { indent: "-1" },
+        { indent: "+1" },
+      ],
+      ["link", "image"],
+      [{ align: [] }, { color: [] }, { background: [] }], // dropdown with defaults from theme
+      ["clean"],
+    ],
+  };
 
-  return <ReactQuill className='editor-styles' theme="snow" value={value} onChange={onChange} modules={modules} formats={formats} />;
+  return <ReactQuill theme="snow" value={value} onChange={onChange} modules={modules} formats={formats} />;
 };
 
 export default NoticeEditor;

--- a/src/app/(community)/(components)/NoticeEditor.tsx
+++ b/src/app/(community)/(components)/NoticeEditor.tsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import 'react-quill/dist/quill.snow.css';
-import { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
+import { Quill } from 'react-quill';
 
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 
@@ -9,8 +10,38 @@ interface NoticeEditorProps {
   onChange: (content: string) => void;
 }
 
+const formats = [
+  'font',
+  'header',
+  'bold',
+  'italic',
+  'underline',
+  'strike',
+  'blockquote',
+  'list',
+  'bullet',
+  'indent',
+  'link',
+  'align',
+  'color',
+  'background',
+  'size',
+  'h1',
+];
+
 const NoticeEditor = ({ value, onChange }: NoticeEditorProps): ReactElement => {
-  return <ReactQuill theme="snow" value={value} onChange={onChange} />;
+  const modules = useMemo(
+    () => ({
+      toolbar: [
+        [{ header: '1' }, { header: '2' }],
+        ['bold', 'italic', 'underline', 'strike'],
+        ['link', 'image']
+      ]
+    }),
+    []
+  );
+
+  return <ReactQuill className='editor-styles' theme="snow" value={value} onChange={onChange} modules={modules} formats={formats} />;
 };
 
 export default NoticeEditor;

--- a/src/app/(community)/(components)/NoticeEditor.tsx
+++ b/src/app/(community)/(components)/NoticeEditor.tsx
@@ -1,59 +1,16 @@
-import {
-  useMemo,
-  useState,
-} from 'react';
-import ReactQuill, { Quill } from 'react-quill';
+import dynamic from 'next/dynamic';
 import 'react-quill/dist/quill.snow.css';
+import { ReactElement } from 'react';
 
-const formats = [
-  'font',
-  'header',
-  'bold',
-  'italic',
-  'underline',
-  'strike',
-  'blockquote',
-  'list',
-  'bullet',
-  'indent',
-  'link',
-  'align',
-  'color',
-  'background',
-  'size',
-  'h1',
-];
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 
-export const QuillEditor = () => {
-  
- const [values, setValues] = useState("");
-  
- const modules = useMemo(() => {
-    return {
-      toolbar: {
-        container: [
-          [{ size: ['small', false, 'large', 'huge'] }],
-          [{ align: [] }],
-          ['bold', 'italic', 'underline', 'strike'],
-          [{ list: 'ordered' }, { list: 'bullet' }],
-          [
-            {
-              color: [],
-            },
-            { background: [] },
-          ],
-        ],
-      },
-    };
-  }, []);
-
-	return(
-     <ReactQuill
-      theme="snow"
-      modules={modules}
-      formats={formats}
-      value={values}
-      onChange={setValues}
-    />
-    )
+interface NoticeEditorProps {
+  value: string;
+  onChange: (content: string) => void;
 }
+
+const NoticeEditor = ({ value, onChange }: NoticeEditorProps): ReactElement => {
+  return <ReactQuill theme="snow" value={value} onChange={onChange} />;
+};
+
+export default NoticeEditor;

--- a/src/app/(community)/(components)/PostForm.tsx
+++ b/src/app/(community)/(components)/PostForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 // import ReactQuill, { Quill } from 'react-quill';
 // import 'react-quill/dist/quill.snow.css';
-
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/utils/supabase/supabase';
 import { useQuery } from '@tanstack/react-query';
@@ -137,7 +136,7 @@ const PostForm = () => {
         <label></label>
         <input type="text" value={title} onChange={handleTitle} placeholder=" 제목을 입력해 주세요." />
       </div>
-      <NoticeEditor value={content} onChange={handleEditorChange} />
+      <NoticeEditor value={content} onChange={handleEditorChange}/>
 
       {/* <div>
         <textarea value={content} onChange={handleContent} placeholder=" 내용을 입력해 주세요."></textarea>

--- a/src/app/(community)/(components)/PostForm.tsx
+++ b/src/app/(community)/(components)/PostForm.tsx
@@ -1,57 +1,58 @@
 'use client';
-import ReactQuill, { Quill } from 'react-quill';
-import 'react-quill/dist/quill.snow.css';
+// import ReactQuill, { Quill } from 'react-quill';
+// import 'react-quill/dist/quill.snow.css';
 
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/utils/supabase/supabase';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { ChangeEvent, FormEvent, useMemo, useState } from 'react';
+import NoticeEditor from './NoticeEditor';
 
 const PostForm = () => {
   const { getCurrentUserProfile } = useAuth();
   const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState<string>('');
   const [category, setCategory] = useState('질문');
   const router = useRouter();
 
-  const formats = [
-    'font',
-    'header',
-    'bold',
-    'italic',
-    'underline',
-    'strike',
-    'blockquote',
-    'list',
-    'bullet',
-    'indent',
-    'link',
-    'align',
-    'color',
-    'background',
-    'size',
-    'h1',
-  ];
+  // const formats = [
+  //   'font',
+  //   'header',
+  //   'bold',
+  //   'italic',
+  //   'underline',
+  //   'strike',
+  //   'blockquote',
+  //   'list',
+  //   'bullet',
+  //   'indent',
+  //   'link',
+  //   'align',
+  //   'color',
+  //   'background',
+  //   'size',
+  //   'h1',
+  // ];
 
- const modules = useMemo(() => {
-    return {
-      toolbar: {
-        container: [
-          [{ size: ['small', false, 'large', 'huge'] }],
-          [{ align: [] }],
-          ['bold', 'italic', 'underline', 'strike'],
-          [{ list: 'ordered' }, { list: 'bullet' }],
-          [
-            {
-              color: [],
-            },
-            { background: [] },
-          ],
-        ],
-      },
-    };
-  }, []);
+  //  const modules = useMemo(() => {
+  //     return {
+  //       toolbar: {
+  //         container: [
+  //           [{ size: ['small', false, 'large', 'huge'] }],
+  //           [{ align: [] }],
+  //           ['bold', 'italic', 'underline', 'strike'],
+  //           [{ list: 'ordered' }, { list: 'bullet' }],
+  //           [
+  //             {
+  //               color: [],
+  //             },
+  //             { background: [] },
+  //           ],
+  //         ],
+  //       },
+  //     };
+  //   }, []);
 
   const {
     data: profile,
@@ -65,7 +66,7 @@ const PostForm = () => {
   if (isLoading) return <div>Loading profile...</div>;
   if (error) return <div>An error occurred: {error instanceof Error ? error.message : 'Unknown error'}</div>;
 
-  const handleTitle = (e: any) => {
+  const handleTitle = (e: ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
   };
 
@@ -73,16 +74,20 @@ const PostForm = () => {
   //   setContent(e.target.value);
   // };
 
-  const handleCategory = (e: any) => {
+  const handleCategory = (e: ChangeEvent<HTMLSelectElement>) => {
     setCategory(e.target.value);
   };
 
-  const handleCancel = (e: any) => {
-    e.preventDefault(); 
+  const handleCancel = (e: FormEvent) => {
+    e.preventDefault();
     router.push('/community-list');
   };
 
-  const handleNewPost = async (e: any) => {
+  const handleEditorChange = (content: string) => {
+    setContent(content);
+  };
+
+  const handleNewPost = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (!profile) {
@@ -132,16 +137,11 @@ const PostForm = () => {
         <label></label>
         <input type="text" value={title} onChange={handleTitle} placeholder=" 제목을 입력해 주세요." />
       </div>
+      <NoticeEditor value={content} onChange={handleEditorChange} />
+
       {/* <div>
         <textarea value={content} onChange={handleContent} placeholder=" 내용을 입력해 주세요."></textarea>
       </div> */}
-      <ReactQuill
-      theme="snow"
-      modules={modules}
-      formats={formats}
-      value={content}
-      onChange={setContent}
-    />
       <div>
         <button onClick={handleCancel}>취소</button>
         <button type="submit">작성</button>

--- a/src/app/(community)/(components)/PostForm.tsx
+++ b/src/app/(community)/(components)/PostForm.tsx
@@ -15,6 +15,10 @@ const PostForm = () => {
   const [category, setCategory] = useState('질문');
   const router = useRouter();
 
+  const editerStyle = {
+    
+  }
+
   // const formats = [
   //   'font',
   //   'header',
@@ -136,7 +140,9 @@ const PostForm = () => {
         <label></label>
         <input type="text" value={title} onChange={handleTitle} placeholder=" 제목을 입력해 주세요." />
       </div>
-      <NoticeEditor value={content} onChange={handleEditorChange}/>
+      <div>
+        <NoticeEditor value={content} onChange={handleEditorChange} />
+      </div>
 
       {/* <div>
         <textarea value={content} onChange={handleContent} placeholder=" 내용을 입력해 주세요."></textarea>

--- a/src/app/(community)/community-list/[id]/page.tsx
+++ b/src/app/(community)/community-list/[id]/page.tsx
@@ -14,7 +14,7 @@ import { FaHeart } from 'react-icons/fa';
 
 import type { PostDetailDateType } from '@/types/posts';
 
-const page = () => {
+const DetailPage = () => {
   const [post, setPost] = useState<PostDetailDateType>();
   const params = useParams();
 
@@ -89,4 +89,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default DetailPage;

--- a/src/app/(community)/community-list/[id]/page.tsx
+++ b/src/app/(community)/community-list/[id]/page.tsx
@@ -77,7 +77,7 @@ const DetailPage = () => {
                   </button>
                 </div>
               </div>
-              <p className="m-5 text-blackColor" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}></p>
+              <p className="ql-editor m-5 text-blackColor" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}></p>
               <div className="border-solid border-t-2">
                 <span>댓글</span>
                 <CommentList postId={params.id} />

--- a/src/app/(community)/community-list/[id]/page.tsx
+++ b/src/app/(community)/community-list/[id]/page.tsx
@@ -6,11 +6,13 @@ import CommentForm from '../../(components)/CommentForm';
 import CommentList from '../../(components)/CommentList';
 import CommunityMenu from '../../(components)/CommunityMenu';
 import CommunityForm from '../../(components)/CommunityForm';
+import DOMPurify from 'dompurify';
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { supabase } from '@/utils/supabase/supabase';
 import { formatToLocaleDateTimeString } from '@/utils/date';
 import { FaHeart } from 'react-icons/fa';
+
 
 import type { PostDetailDateType } from '@/types/posts';
 
@@ -75,7 +77,7 @@ const DetailPage = () => {
                   </button>
                 </div>
               </div>
-              <p className="m-5 text-blackColor">{post.content}</p>
+              <p className="m-5 text-blackColor" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}></p>
               <div className="border-solid border-t-2">
                 <span>댓글</span>
                 <CommentList postId={params.id} />

--- a/src/app/(community)/community-list/page.tsx
+++ b/src/app/(community)/community-list/page.tsx
@@ -14,15 +14,13 @@ const CommunityPage = () => {
       <div className="flex">
         <div>
           <CommunityMenu setSelectedCategory={setSelectedCategory} />
+          <button>
+            <a href="/community-post">작성하기</a>
+          </button>
         </div>
-        <div className='flex justify-center items-center w-full'>
+        <div className="flex justify-center w-full">
           <CommunityForm selectedCategory={selectedCategory} />
         </div>
-      </div>
-      <div>
-        <button>
-          <a href="/community-post">작성하기</a>
-        </button>
       </div>
     </article>
   );

--- a/src/app/(community)/community-list/page.tsx
+++ b/src/app/(community)/community-list/page.tsx
@@ -14,9 +14,11 @@ const CommunityPage = () => {
       <div className="flex">
         <div>
           <CommunityMenu setSelectedCategory={setSelectedCategory} />
-          <button>
-            <a href="/community-post">작성하기</a>
-          </button>
+          <div className='flex justify-center pt-64'>
+            <button className="">
+              <a href="/community-post">작성하기</a>
+            </button>
+          </div>
         </div>
         <div className="flex justify-center w-full">
           <CommunityForm selectedCategory={selectedCategory} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -172,6 +172,17 @@ a {
   transition: opacity 300ms, transform 300ms;
 }
 
-strong {
+.ql-editor strong, em {
   font-weight: bold;
+}
+.ql-editor em {
+  font-style: italic;
+}
+
+.ql-editor h1 {
+  font-size: xx-large;
+}
+
+.ql-editor h2 {
+  font-size: x-large;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -149,3 +149,7 @@ a {
   text-decoration: none;
   color: inherit;
 }
+
+strong {
+  font-weight: bold;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,6 +967,13 @@
   dependencies:
     "@tanstack/query-core" "5.28.9"
 
+"@types/dompurify@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.0.5.tgz#02069a2fcb89a163bacf1a788f73cb415dd75cb7"
+  integrity sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==
+  dependencies:
+    "@types/trusted-types" "*"
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -1010,6 +1017,11 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/trusted-types@*":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/ws@^8.5.10":
   version "8.5.10"
@@ -1573,6 +1585,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dompurify@^3.0.11:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.11.tgz#c163f5816eaac6aeef35dae2b77fca0504564efe"
+  integrity sha512-Fan4uMuyB26gFV3ovPoEoQbxRRPfTu3CvImyZnhGq5fsIEO+gEFLp45ISFt+kQBWsK5ulDdT0oV28jS1UrwQLg==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-87

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] react-quill 기능 구현
- [x] dompurify 라이브러리 설치
- [ ] 첨부 이미지 supabase 에 저장

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- react-quill 사용해서 post 페이지에 추가했습니다. 
- dangerouslySetInnerHTML 사용해서 작성 게시글 detail 페이지에서는 html 태그 없이 보이도록 했습니다. 
추가로 dangerouslySetInnerHTML 을 사용하게 되면 보안상의 문제가 생길 수 있어서 DOMPurify 라이브러리를 설치했습니다. 
해당 라이브러리는  JS 코드는 실행되지 않고 html만 그려주게 만들어주는 기능을 가지고 있어서 보안상의 문제 없이 사용할 수 있습니다!
- 현재 적용되는 기능은 글씨 크기, 굵기, 기울기, 밑줄, 취소선, 글씨 배경색, 글씨 색, 링크, 이미지첨부, 텍스트 정렬 기능, 리스트 적용 가능 합니다.
- 이미지 첨부도 가능한데 아직 supabase 에 저장하는 기능은 구현중입니다. image 첨부 시 중앙에 위치할 수 있는지 구현해보겠습니다.

Community-list/[id]/page.tsx
```tsx
<p
className="ql-editor m-5 text-blackColor"
dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}
></p>
```

## 🚨 TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요. -->
초기에 underline 이랑 strike 같은 몇몇 서식은 적용이 되는데 대부분의 서식이 기능이 안되는 문제가 있었습니다. 해당 문제는 global.css 에 스타일을 추가해서 content 내용 보여주는 p 태그 안에 class 로 추가하여 적용되도록 했습니다.

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
![image](https://github.com/mm-easy/mm-easy/assets/139940350/bf380297-9173-487d-9828-669a8bc0adf4)
글씨 크기, 굵기, 기울기, 밑줄, 취소선, 글씨 배경색, 글씨색, 기능 적용 모습입니다.

![image](https://github.com/mm-easy/mm-easy/assets/139940350/b121ea00-011e-49c1-9670-b8dbcbff26c0)
image 파일 적용 모습입니다.


## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
