### PR TITLE
[feat] quizzes 테이블에서 불러와서 출력

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,12 +2,7 @@
 const nextConfig = {
   reactStrictMode: false,
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'via.placeholder.com'
-      }
-    ]
+    domains: ['icnlbuaakhminucvvzcj.supabase.co', 'via.placeholder.com']
   }
 };
 

--- a/src/api/quizzes.ts
+++ b/src/api/quizzes.ts
@@ -38,9 +38,7 @@ export const uploadImageToStorage = async (imgFile: File | null, fileName: strin
 export const insertQuizToTable = async (newQuiz: Quiz) => {
   try {
     const { data, error } = await supabase.from('quizzes').insert([newQuiz]).select('*');
-    if (error) {
-      throw error;
-    }
+    if (error) throw error;
     const quizId = data?.[0].id;
     return quizId;
   } catch (error) {
@@ -54,9 +52,7 @@ export const insertQuizToTable = async (newQuiz: Quiz) => {
 export const insertQuestionsToTable = async (newQuestions: QuestionsToInsert) => {
   try {
     const { data, error } = await supabase.from('questions').insert([newQuestions]).select('*');
-    if (error) {
-      throw error;
-    }
+    if (error) throw error;
     return data;
   } catch (error) {
     console.error('문제 등록 실패', error);
@@ -70,16 +66,26 @@ export const insertOptionsToTable = async (newOptions: OptionsToInsert[]) => {
   try {
     const insertPromises = newOptions.map(async (option) => {
       const { data, error } = await supabase.from('question_options').insert([option]).select('*');
-      if (error) {
-        throw error;
-      }
+      if (error) throw error;
       return data;
     });
     const insertResults = await Promise.all(insertPromises);
     return insertResults;
   } catch (error) {
     console.error('선택지 등록 실패', error);
-    alert('일시적인 오류 발생');
+    alert('객관식 선택지를 등록하지 못했습니다. 다시 시도하세요.');
+    throw error;
+  }
+};
+
+export const getQuizzes = async () => {
+  try {
+    const { data, error } = await supabase.from('quizzes').select('*');
+    if (error) throw error;
+    return data;
+  } catch (error) {
+    console.error('퀴즈 목록 받아오기 실패', error);
+    alert('일시적으로 퀴즈 목록을 받아오지 못했습니다. 다시 시도하세요.');
     throw error;
   }
 };

--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -13,6 +13,7 @@ import { CancelButton, SubmitButton } from '@/components/common/FormButtons';
 import { generateFileName, generateImgFileName } from '@/utils/generateFileName';
 import { uploadImageToStorage, uploadThumbnailToStorage } from '@/api/quizzes';
 import { useSubmitOptions, useSubmitQuestions, useSubmitQuiz } from '../mutations';
+import { toast } from 'react-toastify';
 
 import { QuestionType, type Question, type Quiz, QuestionsToInsert } from '@/types/quizzes';
 
@@ -21,7 +22,9 @@ const QuizForm = () => {
   const [level, setLevel] = useState<number>(0);
   const [title, setTitle] = useState('');
   const [info, setInfo] = useState('');
-  const [selectedImg, setSelectedImg] = useState('https://via.placeholder.com/144x144');
+  const [selectedImg, setSelectedImg] = useState(
+    'https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/tempThumbnail.png'
+  );
   const [file, setFile] = useState<File | null>(null);
 
   /** 퀴즈 등록 mutation */
@@ -47,7 +50,7 @@ const QuizForm = () => {
         }
       ],
       img_file: null,
-      img_url: 'https://via.placeholder.com/570x160',
+      img_url: 'https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/tempThumbnail.png',
       correct_answer: ''
     },
     {
@@ -67,7 +70,7 @@ const QuizForm = () => {
         }
       ],
       img_file: null,
-      img_url: 'https://via.placeholder.com/570x160',
+      img_url: 'https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/tempThumbnail.png',
       correct_answer: ''
     }
   ]);
@@ -133,19 +136,19 @@ const QuizForm = () => {
             }
           ],
           img_file: null,
-          img_url: 'https://via.placeholder.com/200x200',
+          img_url:
+            'https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/tempThumbnail.png',
           correct_answer: ''
         }
       ]);
     } else {
-      alert('최대 5개까지만 문제를 추가할 수 있습니다.');
+      toast.warning('최대 5개까지만 문제를 추가할 수 있습니다.');
       return;
     }
   };
 
   /** 등록 버튼 클릭 핸들러 */
   const handleSubmitBtn = async () => {
-    console.log('끼히히히', questions);
     if (!level) {
       alert('난이도를 선택해주세요.');
       return;
@@ -192,7 +195,9 @@ const QuizForm = () => {
         level,
         title,
         info,
-        thumbnail_img_url: imgUrl || 'https://via.placeholder.com/200x200'
+        thumbnail_img_url:
+          imgUrl ||
+          'https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/tempThumbnail.png'
       };
 
       const insertQuizResult = await insertQuizMutation.mutateAsync(newQuiz);
@@ -236,7 +241,7 @@ const QuizForm = () => {
                 alt="샘플이미지"
                 width={144}
                 height={144}
-                className="object-cover cursor-pointer"
+                className="w-full h-full object-cover cursor-pointer"
               />
               <input type="file" id="fileInput" ref={fileInputRef} className="hidden" onChange={handleChangeImg} />
             </div>

--- a/src/app/(quiz)/(components)/QuizList.tsx
+++ b/src/app/(quiz)/(components)/QuizList.tsx
@@ -1,45 +1,31 @@
+'use client';
+
 import Image from 'next/image';
 
-const QuizList = () => {
+import { Quiz } from '@/types/quizzes';
+
+const QuizList = ({ quizLevelSelected }: { quizLevelSelected: Quiz[] }) => {
   return (
     <main className="p-5 flex flex-col gap-4 items-center">
-      <div className="flex gap-5 flex-wrap mt-5">
-        <div className="flex flex-col gap-3">
-          <div className="border-solid border border-pointColor1 rounded-md overflow-hidden">
-            <Image src="https://via.placeholder.com/250x250" alt="퀴즈 썸네일" width={250} height={250} />
+      {quizLevelSelected.length === 0 && <div className="p-36">해당 난이도에 아직 등록된 퀴즈가 없습니다.</div>}
+      <div className="w-8/12 grid grid-cols-4 mt-5 place-items-center">
+        {quizLevelSelected.map((item) => (
+          <div key={item.id} className="flex flex-col gap-3 mb-8">
+            <div className="border-solid border border-pointColor1 rounded-md overflow-hidden w-[250px] h-[250px]">
+              <Image
+                src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/${item.thumbnail_img_url}`}
+                alt="퀴즈 썸네일"
+                width={250}
+                height={250}
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <div className="flex flex-col">
+              <p className="font-bold text-lg">{item.title}</p>
+              <p>{item.info}</p>
+            </div>
           </div>
-          <div className="flex flex-col gap-1">
-            <p className="font-bold text-lg">퀴즈 제목입니다</p>
-            <p>퀴즈 설명입니다</p>
-          </div>
-        </div>
-        <div className="flex flex-col gap-3">
-          <div className="border-solid border border-pointColor1 rounded-md overflow-hidden">
-            <Image src="https://via.placeholder.com/250x250" alt="퀴즈 썸네일" width={250} height={250} />
-          </div>
-          <div className="flex flex-col gap-1">
-            <p className="font-bold text-lg">퀴즈 제목입니다</p>
-            <p>퀴즈 설명입니다</p>
-          </div>
-        </div>
-        <div className="flex flex-col gap-3">
-          <div className="border-solid border border-pointColor1 rounded-md overflow-hidden">
-            <Image src="https://via.placeholder.com/250x250" alt="퀴즈 썸네일" width={250} height={250} />
-          </div>
-          <div className="flex flex-col gap-1">
-            <p className="font-bold text-lg">퀴즈 제목입니다</p>
-            <p>퀴즈 설명입니다</p>
-          </div>
-        </div>
-        <div className="flex flex-col gap-3">
-          <div className="border-solid border border-pointColor1 rounded-md overflow-hidden">
-            <Image src="https://via.placeholder.com/250x250" alt="퀴즈 썸네일" width={250} height={250} />
-          </div>
-          <div className="flex flex-col gap-1">
-            <p className="font-bold text-lg">퀴즈 제목입니다</p>
-            <p>퀴즈 설명입니다</p>
-          </div>
-        </div>
+        ))}
       </div>
     </main>
   );

--- a/src/app/(quiz)/(components)/SelectQuizLevel.tsx
+++ b/src/app/(quiz)/(components)/SelectQuizLevel.tsx
@@ -1,43 +1,84 @@
 'use client';
 
-import { BlueButton, CancelButton } from '@/components/common/FormButtons';
 import Image from 'next/image';
+import QuizList from './QuizList';
+import { BlueButton } from '@/components/common/FormButtons';
 import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { getQuizzes } from '@/api/quizzes';
+
+import type { Quiz } from '@/types/quizzes';
+import { useState } from 'react';
 
 const SelectQuizLevel = () => {
+  const [quizLevelSelected, setQuizLevelSelected] = useState<Quiz[]>([]);
   const router = useRouter();
+
+  /** 퀴즈 만들기 버튼 클릭 시 */
   const handleMakeQuizBtn = () => {
     router.push('/quiz-form');
   };
+
+  /** quizzes 테이블에서 리스트 가져오기 */
+  const { data, isLoading, isError } = useQuery<Quiz[]>({
+    queryFn: async () => {
+      try {
+        const data = await getQuizzes();
+        setQuizLevelSelected(data);
+        return data;
+      } catch (error) {
+        return [];
+      }
+    },
+    queryKey: ['quizzes'],
+    refetchOnWindowFocus: false
+  });
+
+  if (isLoading) return <div>데이터 로드 중...</div>;
+  if (isError) return <div>데이터 로드 실패</div>;
+  if (!data) return;
+
+  /** 클릭하여 퀴즈 레벨 필터링 */
+  const handleSelectLevel = (level: number) => {
+    const filteredQuizzes = data.filter((item) => item.level === level);
+    setQuizLevelSelected(filteredQuizzes);
+  };
+
   return (
-    <main className="w-full bg-pointColor1 border-b-2 border-pointColor1 flex flex-col justify-center items-center">
-      <div className="mt-5 mr-1/4 ml-auto">
-        <BlueButton text="퀴즈 만들기" onClick={handleMakeQuizBtn} width="w-36" />
-      </div>
-      <div className="flex items-end gap-1 overflow-hidden">
-        <Image
-          src="https://via.placeholder.com/350x240"
-          alt="초급"
-          width={350}
-          height={240}
-          className="object-none transform translate-y-[40%] hover:translate-y-[10%] transition-transform duration-500 ease-in-out"
-        />
-        <Image
-          src="https://via.placeholder.com/350x240"
-          alt="중급"
-          width={350}
-          height={240}
-          className="object-none transform translate-y-[40%] hover:translate-y-[10%] transition-transform duration-500 ease-in-out"
-        />
-        <Image
-          src="https://via.placeholder.com/350x240"
-          alt="고급"
-          width={350}
-          height={240}
-          className="object-none transform translate-y-[40%] hover:translate-y-[10%] transition-transform duration-500 ease-in-out"
-        />
-      </div>
-    </main>
+    <>
+      <main className="w-full bg-pointColor1 border-b-2 border-pointColor1 flex flex-col justify-center items-center">
+        <div className="mt-5 mr-1/4 ml-auto">
+          <BlueButton text="퀴즈 만들기" onClick={handleMakeQuizBtn} width="w-36" />
+        </div>
+        <div className="flex items-end gap-1 overflow-hidden">
+          <Image
+            src="https://via.placeholder.com/350x240"
+            alt="초급"
+            width={350}
+            height={240}
+            className="object-none transform translate-y-[40%] hover:translate-y-[10%] transition-transform duration-500 ease-in-out"
+            onClick={() => handleSelectLevel(1)}
+          />
+          <Image
+            src="https://via.placeholder.com/350x240"
+            alt="중급"
+            width={350}
+            height={240}
+            className="object-none transform translate-y-[40%] hover:translate-y-[10%] transition-transform duration-500 ease-in-out"
+            onClick={() => handleSelectLevel(2)}
+          />
+          <Image
+            src="https://via.placeholder.com/350x240"
+            alt="고급"
+            width={350}
+            height={240}
+            className="object-none transform translate-y-[40%] hover:translate-y-[10%] transition-transform duration-500 ease-in-out"
+            onClick={() => handleSelectLevel(3)}
+          />
+        </div>
+      </main>
+      <QuizList quizLevelSelected={quizLevelSelected} />
+    </>
   );
 };
 

--- a/src/app/(quiz)/quiz-list/page.tsx
+++ b/src/app/(quiz)/quiz-list/page.tsx
@@ -1,13 +1,11 @@
 import SubHeader from '@/components/common/SubHeader';
 import SelectQuizLevel from '../(components)/SelectQuizLevel';
-import QuizList from '../(components)/QuizList';
 
 const QuizListPage = () => {
   return (
     <main className="h-full">
       <SubHeader text="퀴즈" />
       <SelectQuizLevel />
-      <QuizList />
     </main>
   );
 };


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-132
🔗 https://coding-legend.atlassian.net/browse/MMEASY-133
🔗 https://coding-legend.atlassian.net/browse/MMEASY-159

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] quizzes 테이블에서 데이터 불러오기
- [x] SelectQuizLevel 컴포넌트에서 레벨 선택 시 퀴즈 필터링
- [x] 필터링한 퀴즈 데이터를 QuizList 컴포넌트에서 출력

## 🧑🏻‍💻 개발 내용
`quiz-list` 기능을 대강 구현했습니다. 그런데 전체 레벨 모아보기 기능이 추가되면 더 좋을 것 같아요. 그리고 기획 초반에 잠시 얘기 나왔던 퀴즈 카테고리도 추가해보면 더 좋을 것 같습니다.

## 🚨 TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요. -->
flex flex-wrap gap-4 이런식으로 했더니 제일 오른쪽 항목에도 오른쪽에 gap이 생겨서 가운데 정렬이 어려웠는데 grid 썼더니 해결됐습니다. 매번 flex만 도배하는데 grid가 이렇게 유용하네요! 근데 브라우저 너비가 줄어들면 요소들이 겹쳐지는 문제점이 있습니다. 나중에 해결하겠습니다..
```
<div className="w-8/12 grid grid-cols-4 mt-5 place-items-center">
        {quizLevelSelected.map((item) => (
          <div key={item.id} className="flex flex-col gap-3 mb-8">
            <div className="border-solid border border-pointColor1 rounded-md overflow-hidden w-[250px] h-[250px]">
              <Image
                src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/${item.thumbnail_img_url}`}
                alt="퀴즈 썸네일"
                width={250}
                height={250}
                className="w-full h-full object-cover"
              />
            </div>
            <div className="flex flex-col">
              <p className="font-bold text-lg">{item.title}</p>
              <p>{item.info}</p>
            </div>
          </div>
        ))}
      </div>
```

## 📸 스크린샷(선택)
![image](https://github.com/mm-easy/mm-easy/assets/153061626/8e145062-079f-4a0e-9d82-8133297d4594)