### PR TITLE
[style] 타자연습 페이지 레이아웃 CSS

### DIFF
--- a/src/app/typing-game/page.tsx
+++ b/src/app/typing-game/page.tsx
@@ -1,4 +1,4 @@
-"use client"
+'use client';
 
 import { useState, useEffect } from 'react';
 import { wordList } from '@/utils/wordList';
@@ -7,11 +7,10 @@ import { Word } from '@/types/word';
 const difficultySettings = {
   1: { speed: 10, interval: 2000 },
   2: { speed: 20, interval: 1000 },
-  3: { speed: 30, interval: 500 },
+  3: { speed: 30, interval: 500 }
 };
 
-const maxDifficulty = Object.keys(difficultySettings).length; 
-
+const maxDifficulty = Object.keys(difficultySettings).length;
 
 const TypingGamePage = () => {
   const [words, setWords] = useState<Word[]>([]);
@@ -24,7 +23,7 @@ const TypingGamePage = () => {
   const gameAreaWidth = window.innerWidth;
   const maxLives = 5;
   const gameAreaHeight = 600;
-  const wordHeight = 80; 
+  const wordHeight = 80;
 
   useEffect(() => {
     let interval: NodeJS.Timeout;
@@ -34,7 +33,7 @@ const TypingGamePage = () => {
           id: Date.now(),
           text: wordList[Math.floor(Math.random() * wordList.length)],
           top: 0,
-          left: Math.random() * (gameAreaWidth - 200),
+          left: Math.random() * (gameAreaWidth - 200)
         };
         setWords((prevWords) => [...prevWords, newWord]);
       }, 3000);
@@ -46,15 +45,15 @@ const TypingGamePage = () => {
     let interval: NodeJS.Timeout;
     if (gameStarted) {
       interval = setInterval(() => {
-        const updatedWords = words.map(word => ({
+        const updatedWords = words.map((word) => ({
           ...word,
           top: word.top + 10
         }));
 
-        const outOfBoundWords = updatedWords.filter(word => word.top >= gameAreaHeight - wordHeight);
+        const outOfBoundWords = updatedWords.filter((word) => word.top >= gameAreaHeight - wordHeight);
         if (outOfBoundWords.length > 0) {
           setLives((prevLives) => Math.max(0, prevLives - outOfBoundWords.length));
-          setWords(updatedWords.filter(word => word.top < gameAreaHeight - wordHeight));
+          setWords(updatedWords.filter((word) => word.top < gameAreaHeight - wordHeight));
         } else {
           setWords(updatedWords);
         }
@@ -101,47 +100,66 @@ const TypingGamePage = () => {
     setLives(maxLives);
   };
 
-  const lifePercentage = (lives / maxLives) * 100;
+  const lifePercentage = (lives / maxLives) * 60;
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-100">
-    <header className="flex justify-between items-center bg-white">
-    <div className="flex items-center">
-      <div className="mr-2">난이도</div>
-      <div>{difficulty}</div>
+    <div className="flex flex-col bg-gray-100">
+      <header className="h-[8vh] flex leading-[7.5vh] font-bold border-solid border-b-2 border-pointColor1">
+        <h2 className="w-[8%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
+          난이도
+        </h2>
+        <h3 className="w-[8%] h-full text-center text-pointColor2 border-solid border-r-2 border-pointColor1">
+          {difficulty}
+        </h3>
+        <h2 className="w-[8%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
+          점수
+        </h2>
+        <h3 className="w-[8%] h-full text-center text-pointColor2 border-solid border-r-2 border-pointColor1">
+          {score}
+        </h3>
+        <h2 className="w-[8%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
+          생명
+        </h2>
+        <div className="h-[calc(8vh-2px)] bg-pointColor2" style={{ width: `${lifePercentage}%` }}></div>
+      </header>
+      <div className="h-[76vh] flex-grow relative">
+        {gameStarted ? (
+          <>
+            {words.map((word) => (
+              <div
+                key={word.id}
+                className="absolute bg-pointColor1 text-white p-2 rounded"
+                style={{ top: `${word.top}px`, left: `${word.left}px` }}
+              >
+                {word.text}
+              </div>
+            ))}
+            <form
+              onSubmit={handleSubmit}
+              className="h-[10vh] flex gap-3 justify-center absolute bottom-0 left-0 right-0 p-4 bg-white"
+            >
+              <input
+                type="text"
+                value={input}
+                placeholder="입력창"
+                onChange={handleInput}
+                className="w-[60vw] pl-4 text-pointColor1 border border-pointColor1 rounded-md"
+              />
+              <button type="submit" className="w-[10vw] bg-pointColor1 text-white rounded-md">
+                입력
+              </button>
+            </form>
+          </>
+        ) : (
+          <div className="flex items-center justify-center h-full">
+            <button onClick={startGame} className="bg-pointColor1 text-white p-4 rounded">
+              게임 시작!
+            </button>
+          </div>
+        )}
       </div>
-      <div className="flex items-center">
-      <div className='mr-2'>점수</div>
-      <div>{score}</div>
-      </div>
-      <div className="flex items-center">
-        <div className="text-red-500 mr-2">생명</div>
-        <div className="w-64 bg-gray-200 h-10">
-          <div className="bg-red-500 h-10" style={{ width: `${lifePercentage}%` }}></div>
-        </div>
-      </div>
-    </header>
-    <div className="flex-grow relative">
-      {gameStarted ? (
-        <>
-          {words.map(word => (
-            <div key={word.id} className="absolute bg-pointColor1 text-white p-2 rounded" style={{ top: `${word.top}px`, left: `${word.left}px` }}>
-              {word.text}
-            </div>
-          ))}
-          <form onSubmit={handleSubmit} className="absolute bottom-0 left-0 right-0 p-4 bg-white">
-            <input type="text" value={input} onChange={handleInput} className="border border-pointColor1 rounded p-2 w-full" />
-            <button type="submit" className="mt-2 bg-pointColor1 text-white p-2 rounded w-full">입력</button>
-          </form>
-        </>
-      ) : (
-        <div className="flex items-center justify-center h-full">
-          <button onClick={startGame} className="bg-pointColor1 text-white p-4 rounded">게임 시작!</button>
-        </div>
-      )}
     </div>
-  </div>
-);
+  );
 };
 
 export default TypingGamePage;


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-209

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 타자연습 페이지 레이아웃 CSS

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- className 이 많이 길어서.. h2, h3 를 컴포넌트로 나누거나 header 를 분리해두면 좋을 거 같습니다.
- text 부분들을 8% 로 두고, 생명 표시 부분을 60% 로 맞췄습니다.

![스크린샷 2024-04-07 오전 1 51 37](https://github.com/mm-easy/mm-easy/assets/142870577/341a6b38-b3c4-41d0-bccc-133d347b8377)


## 🚨 TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요. -->
- className 벡틱으로 쓰고 style={} 없애려 했는데 적용이 안되네요.. 🥲

```tsx
<div className="h-[calc(8vh-2px)] bg-pointColor2" style={{ width: `${lifePercentage}%` }}></div>
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
<img width="1437" alt="스크린샷 2024-04-07 오전 1 49 35" src="https://github.com/mm-easy/mm-easy/assets/142870577/8caa164b-f9c2-41ca-a4da-11396273da54">

## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
- calc 를 쓰면 크기 연산이 가능합니다!

```css
.example {
    font-size: calc(2vw + 10px); /* viewport width에 따라 크기 조절하면서 10px를 추가 */
    padding: 20px; /* 고정된 크기로 픽셀 단위 사용 */
    margin: calc(1vw + 5px) calc(2vw + 10px); /* 세로는 viewport width에 따라, 가로는 픽셀 단위로 사용 */
    width: calc(50% + 20px); /* 백분율로 지정하면서 20px를 추가 */
}
```
