### PR TITLE
[fix] question 첨부 이미지 처리 수정

### DIFF
--- a/src/api/quizzes.ts
+++ b/src/api/quizzes.ts
@@ -22,12 +22,14 @@ export const uploadThumbnailToStorage = async (file: File, fileName: string) => 
 export const uploadImageToStorage = async (imgFile: File | null, fileName: string) => {
   try {
     if (!imgFile) return;
-    const { data, error } = await supabase.storage.from('question-imgs').upload(fileName, imgFile);
+    const { data, error } = await supabase.storage.from('question-imgs').upload(fileName, imgFile, {
+      contentType: imgFile.type
+    });
     if (error) {
       alert('이미지 업로드 중 오류가 발생했습니다. 다시 시도하세요.');
       throw error;
     }
-    return data;
+    return data.path;
   } catch (error) {
     console.error('문제 이미지 업로드 에러 발생', error);
     return null;

--- a/src/components/common/BlueInput.tsx
+++ b/src/components/common/BlueInput.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 interface BlueInputProps {
-  value?: string;
+  value: string;
   onInput?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 interface BlueTextareaProps {
-  value?: string;
+  value: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
@@ -18,23 +18,29 @@ interface BlueLevelSelectProps {
 
 export const BlueInput: React.FC<BlueInputProps> = ({ value, onInput, onChange }) => {
   return (
-    <input
-      className="border border-solid border-pointColor1 w-96 p-2 rounded-md"
-      type="text"
-      value={value}
-      onInput={onInput}
-      onChange={onChange}
-    />
+    <div className="w-full relative">
+      <input
+        className="border border-solid border-pointColor1 w-96 p-2 rounded-md"
+        type="text"
+        value={value}
+        onInput={onInput}
+        onChange={onChange}
+      />
+      <p className="absolute top-0 right-2 pt-3 pr-1 text-sm">{value.length} / 25</p>
+    </div>
   );
 };
 
 export const BlueTextArea: React.FC<BlueTextareaProps> = ({ value, onChange }) => {
   return (
-    <textarea
-      className="border border-solid border-pointColor1 w-[570px] p-2 h-24 rounded-md"
-      value={value}
-      onChange={onChange}
-    />
+    <div className="w-full relative">
+      <textarea
+        className="border border-solid border-pointColor1 w-[570px] p-2 h-24 rounded-md"
+        value={value}
+        onChange={onChange}
+      />
+      <p className="absolute top-0 right-2 pt-3 pr-1 text-sm">{value.length} / 150</p>
+    </div>
   );
 };
 

--- a/src/components/common/SubHeader.tsx
+++ b/src/components/common/SubHeader.tsx
@@ -4,7 +4,7 @@ interface QuizFormHeaderProps {
 
 const SubHeader: React.FC<QuizFormHeaderProps> = ({ text }) => {
   return (
-    <main className="h-[8vh] pl-4 leading-[7vh] bg-bgColor1 border-b-2 border-pointColor1 text-pointColor1">
+    <main className="h-[8vh] pl-10 leading-[8vh] bg-bgColor1 border-b-2 border-pointColor1 text-pointColor1">
       {text}
     </main>
   );

--- a/src/types/quizzes.ts
+++ b/src/types/quizzes.ts
@@ -39,5 +39,6 @@ export type Question = {
 
 export type QuestionsToInsert = Pick<Question, 'title' | 'correct_answer'> & {
   quiz_id: string;
-  question_type: QuestionType;
+  type: QuestionType;
+  img_url: string;
 };


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-120

## ✍️ Task TODOLIST
- [ ] supabase / questions 테이블에 img_url 컬럼 추가
- [ ] questions 첨부 이미지 스토리지에 올린 후 해당 url을 img_url에 insert
- [ ] questions 첨부 이미지가 없는 경우 기본 이미지 주소(현재는 우는고양이 이미지, Thumbnail.png)를 img_url에 insert 

## 🧑🏻‍💻 개발 내용
`quiz-form`에서 '등록하기' 클릭 시 돌아가는 로직을 수정했습니다.

`quiz/components/QuizForm.tsx`
* 첨부한 이미지가 없는 경우 img_url은 null이며, 첨부한 이미지가 있는 경우 img_url은 해당 이미지를 스토리지에 업로드한 주소로 바뀝니다.
```
let img_url = null;
        if (question.img_file) {
          const formattedName = generateImgFileName(question.img_file, question.id);
          img_url = await uploadImageToStorage(question.img_file, formattedName);
        }
```

* 스토리지에 업로드한 주소가 있으면 해당 주소로, 없으면(img_url ===null인 경우) 기본 이미지 주소(tempThumbnail.png)가 questions 테이블의 img_url 컬럼에 들어가게 됩니다.
```
        const newQuestion = {
          quiz_id: insertQuizResult as string,
          title: question.title,
          type: question.type,
          correct_answer: question.correct_answer,
          img_url: img_url || 'tempThumbnail.png'
        };
```

* 스토리지에 questions 첨부 이미지를 올릴 때 파일명은 저희가 input 관리 용도로 넣어뒀던 임시 난수id입니다.

## 📸 스크린샷(선택)
![image](https://github.com/mm-easy/mm-easy/assets/153061626/a981eff2-b292-46f9-8768-7d9ec9838389)
