### PR TITLE
[feat] quiz-form 새로고침/브라우저 닫을 때 경고

### DIFF
--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -18,7 +18,7 @@ import { storageUrl } from '@/utils/supabase/storage';
 
 import { QuestionType, type Question } from '@/types/quizzes';
 import { handleMaxLength } from '@/utils/handleMaxLength';
-// import useConfirmPageLeave from '@/hooks/useConfirmPageLeave';
+import useConfirmPageLeave from '@/hooks/useConfirmPageLeave';
 
 const QuizForm = () => {
   const [scrollPosition, setScrollPosition] = useState<number>(0);
@@ -29,7 +29,7 @@ const QuizForm = () => {
   const [file, setFile] = useState<File | null>(null);
   const [currentUser, setCurrentUser] = useState('');
 
-  // useConfirmPageLeave();
+  useConfirmPageLeave();
 
   useEffect(() => {
     const userDataString = localStorage.getItem('sb-icnlbuaakhminucvvzcj-auth-token');
@@ -223,7 +223,7 @@ const QuizForm = () => {
   };
 
   return (
-    <main className="bg-blue-50 flex gap-5 flex-col justify-center items-center pb-12">
+    <main className="bg-blue-50 flex gap-5 flex-col justify-center items-center">
       <form className="flex flex-col min-w-full" onSubmit={(e) => e.preventDefault()}>
         <div className="p-10 flex flex-col gap-4 bg-bgColor1 justify-center items-center border-solid border-b-2 border-pointColor1">
           <div className="flex gap-10">

--- a/src/hooks/useConfirmPageLeave.tsx
+++ b/src/hooks/useConfirmPageLeave.tsx
@@ -1,32 +1,30 @@
-// 'use client';
+'use client';
 
-// import { useRouter } from 'next/navigation';
-// import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
-// const useConfirmPageLeave = () => {
-//   const router = useRouter();
+const useConfirmPageLeave = () => {
+  const router = useRouter();
 
-//   useEffect(() => {
-//     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-//       event.preventDefault();
-//       event.returnValue = ''; // 이 줄은 브라우저 호환성을 위해 필요합니다.
-//       return '변경된 내용이 있습니다. 정말로 페이지를 이동하시겠습니까?';
-//     };
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+      return '작성하던 내용이 모두 사라집니다. 계속하시겠습니까?';
+    };
 
-//     const handleRouteChangeStart = (url: string) => {
-//       if (!window.confirm('변경된 내용이 있습니다. 정말로 페이지를 이동하시겠습니까?')) {
-//         throw 'routeChange aborted.';
-//       }
-//     };
+    const handlePageUnload = () => {
+      if (!window.confirm('작성하던 내용이 모두 사라집니다. 계속하시겠습니까?')) return;
+    };
 
-//     window.addEventListener('beforeunload', handleBeforeUnload);
-//     router.events.on('routeChangeStart', handleRouteChangeStart);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('unload', handlePageUnload);
 
-//     return () => {
-//       window.removeEventListener('beforeunload', handleBeforeUnload);
-//       router.events.off('routeChangeStart', handleRouteChangeStart);
-//     };
-//   }, []);
-// };
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('unload', handlePageUnload);
+    };
+  }, []);
+};
 
-// export default useConfirmPageLeave;
+export default useConfirmPageLeave;


### PR DESCRIPTION
## 📍 관련 이슈
🔗 https://coding-legend.atlassian.net/browse/MMEASY-225

## ✍️ Task TODOLIST
- [x] 새로고침 시 브라우저 경고
- [x] 창 닫기 시 브라우저 경고

## 🧑🏻‍💻 개발 내용
* 새로고침, 창 닫기 시 경고 띄우게 했습니다. 뒤로가기도 추가해야 하는데 쉽지 않네요.
Next.js 13? 14버전부터 router를 import할 때 next/router가 아니라 next/navigation에서 가져와야 하는데,
next/navigation에는 이전 버전에서 해당 처리 시 사용했던 기능이 없어서 다른 방법을 써야한대요.
챗지피티가 계속 예전 버전 방식만 알려줘서 구글링 많이 해봐야 할 것 같습니다.

* 현재는 새로고침, 창 닫기 시도할 때 무조건 경고가 뜨는데, input에 입력값이 발생했을 때 경고가 뜨게끔 디벨롭 하면 더 좋을 것 같습니다.
```
  useEffect(() => {
    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
      event.preventDefault();
      event.returnValue = '';
      return '작성하던 내용이 모두 사라집니다. 계속하시겠습니까?';
    };

    const handlePageUnload = () => {
      if (!window.confirm('작성하던 내용이 모두 사라집니다. 계속하시겠습니까?')) return;
    };

    window.addEventListener('beforeunload', handleBeforeUnload);
    window.addEventListener('unload', handlePageUnload);

    return () => {
      window.removeEventListener('beforeunload', handleBeforeUnload);
      window.removeEventListener('unload', handlePageUnload);
    };
  }, []);
```


## 📸 스크린샷(선택)
![image](https://github.com/mm-easy/mm-easy/assets/153061626/e399d838-7bf1-4f78-b579-347a8db2ef48)
