### PR TITLE
[feat] 결과 페이지에서 주관형 정답/오답 조건부 렌더링

### DIFF
--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -145,6 +145,7 @@ const QuizTryPage = () => {
           )}
           {questions.map((question) => {
             const { id, title, type, img_url, correct_answer } = question;
+            const usersAnswer = usersAnswers.find((answer) => answer.id === id);
             return (
               <section key={id} className="w-[570px] flex flex-col place-items-center gap-4">
                 <h3 className="self-start text-lg">{`${questions.indexOf(question) + 1}. ${title}`}</h3>
@@ -159,17 +160,27 @@ const QuizTryPage = () => {
                   <Options id={id} resultMode={resultMode} onChange={handleGetAnswer} />
                 ) : (
                   <div className="w-full relative">
-                    <input
-                      type="text"
-                      className="w-full pl-4 py-[9px] border-solid border border-pointColor1 rounded-md"
-                      onChange={(e) => {
-                        handleMaxLength(e, 25);
-                        handleGetAnswer(id, e.target.value);
-                        // handleGradeobjectiveAnswer(id, e.target.value, correct_answer);
-                        // setObjectiveAnswer(e.target.value);
-                      }}
-                    />
-                    {/* <p className="absolute top-0 right-2 pt-3 pr-1 text-sm">{objectiveAnswer.length}/25</p> */}
+                    {resultMode ? (
+                      <p
+                        className={`w-full pl-4 py-[9px] border-solid border ${usersAnswer?.answer === correct_answer ? ' border-pointColor1' : 'border-pointColor2'} rounded-md`}
+                      >
+                        {usersAnswer?.answer}
+                      </p>
+                    ) : (
+                      <>
+                        <input
+                          type="text"
+                          className="w-full pl-4 py-[9px] border-solid border border-pointColor1 rounded-md"
+                          onChange={(e) => {
+                            handleMaxLength(e, 25);
+                            handleGetAnswer(id, e.target.value);
+                            // handleGradeobjectiveAnswer(id, e.target.value, correct_answer);
+                            // setObjectiveAnswer(e.target.value);
+                          }}
+                        />
+                        {/* <p className="absolute top-0 right-2 pt-3 pr-1 text-sm">{objectiveAnswer.length}/25</p> */}
+                      </>
+                    )}
                   </div>
                 )}
               </section>


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-249

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 결과 페이지에서 주관형 정답/오답 조건부 렌더링

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- 정답이면 파란색으로, 아니면 빨간색 보더로 구분했습니다. (테일윈드도 조건부 렌더링이 되더군요..)

quiz/[id]/page.tsx
```tsx
<p className={`w-full pl-4 py-[9px] border-solid border
${usersAnswer?.answer === correct_answer ? ' border-pointColor1' : 'border-pointColor2'} rounded-md`}>
  {usersAnswer?.answer}
</p>
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
<img width="868" alt="스크린샷 2024-04-10 오전 1 48 29" src="https://github.com/mm-easy/mm-easy/assets/142870577/db4a96a7-04b1-409a-9afb-db6b598887e4">


## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
- 조건부 렌더링 참고 링크입니다.

🔗 https://sezzled.tistory.com/13