### PR TITLE
[feat] 결과 페이지에서 선택형 정답/오답 조건부 렌더링 및 좌측 퀴즈 정보 비율 16%로 수정

### DIFF
--- a/src/app/(quiz)/quiz/[id]/Header.tsx
+++ b/src/app/(quiz)/quiz/[id]/Header.tsx
@@ -1,7 +1,7 @@
 const Header = ({ level, title }: { level: number; title: string }) => {
   return (
     <header className="h-[8vh] flex leading-[7.5vh] border-solid border-b-2 border-pointColor1">
-      <h2 className="w-[10%] text-center font-bold text-pointColor1 bg-bgColor1 border-solid border-r-2 border-pointColor1">
+      <h2 className="w-[16%] text-center font-bold text-pointColor1 bg-bgColor1 border-solid border-r-2 border-pointColor1">
         퀴즈 풀기
       </h2>
       <h2 className="w-[8%] text-center font-bold text-pointColor1 bg-bgColor1 border-solid border-r-2 border-pointColor1">

--- a/src/app/(quiz)/quiz/[id]/Options.tsx
+++ b/src/app/(quiz)/quiz/[id]/Options.tsx
@@ -1,15 +1,17 @@
-import { getOptions } from '@/api/question_options';
-import { Option } from '@/types/quizzes';
 import { useQuery } from '@tanstack/react-query';
+import { getOptions } from '@/api/question_options';
+import type { Answer, Option } from '@/types/quizzes';
 
 const Options = ({
   id: questionId,
   resultMode,
+  usersAnswer,
   onChange
 }: {
   id: string | undefined;
   resultMode: boolean;
-  onChange: (id: string | undefined, answer: string | boolean) => void;
+  usersAnswer: Answer | undefined;
+  onChange: (id: string | undefined, answer: string | boolean, option_id?: string) => void;
 }) => {
   const { data, isLoading, isError } = useQuery({
     queryFn: async () => {
@@ -33,12 +35,15 @@ const Options = ({
       {options.map((option) => {
         const { id, content, is_answer } = option;
         return (
-          <div key={id} className="pl-4 py-[9px] flex gap-4 border-solid border border-pointColor1 rounded-md">
+          <div
+            key={id}
+            className={`pl-4 py-[9px] flex gap-4 border-solid border ${resultMode && usersAnswer?.option_id === id ? (is_answer ? 'border-pointColor1 bg-bgColor2' : 'border-pointColor2 bg-bgColor3') : 'border-pointColor1'} rounded-md`}
+          >
             <input
               type="radio"
               disabled={resultMode}
               name={questionId}
-              onChange={() => onChange(questionId, is_answer)}
+              onChange={() => onChange(questionId, is_answer, id)}
             />
             <p>{content}</p>
           </div>

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -114,15 +114,15 @@ const QuizTryPage = () => {
   return (
     <>
       <Header level={level} title={title} />
-      <main className="grid grid-cols-[10%_90%]">
+      <main className="grid grid-cols-[16%_84%]">
         <article className="bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
           <section>
             <Image
               src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/${url}`}
               alt="샘플 이미지"
-              width={144}
-              height={144}
-              className="w-full h-[144px] object-cover border-solid border-b-2 border-pointColor1"
+              width={230}
+              height={230}
+              className="w-full h-[230px] object-cover border-solid border-b-2 border-pointColor1"
             />
             <section className="p-4 flex flex-col gap-4 border-solid border-b-2 border-pointColor1">
               <div>

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -1,23 +1,19 @@
 'use client';
 
 import Image from 'next/image';
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
+import { toast } from 'react-toastify';
+
 import { getQuiz } from '@/api/quizzes';
 import { getQuestions } from '@/api/questions';
-import { formatToLocaleDateTimeString } from '@/utils/date';
-import { QuestionType, type GetQuiz, type Question } from '@/types/quizzes';
-import { useState } from 'react';
-import Options from './Options';
 import { handleMaxLength } from '@/utils/handleMaxLength';
+import { formatToLocaleDateTimeString } from '@/utils/date';
 import Header from './Header';
-import { toast } from 'react-toastify';
-import { SiAnswer } from 'react-icons/si';
+import Options from './Options';
 
-type Answer = {
-  id: string | undefined;
-  answer: string | boolean;
-};
+import { QuestionType, type GetQuiz, type Question, type Answer } from '@/types/quizzes';
 
 const QuizTryPage = () => {
   const { id } = useParams();
@@ -70,12 +66,18 @@ const QuizTryPage = () => {
 
   const questions = questionsData as Question[];
 
-  const handleGetAnswer = (id: string | undefined, answer: string | boolean) => {
+  const handleGetAnswer = (id: string | undefined, answer: string | boolean, option_id?: string) => {
     const idx = usersAnswers.findIndex((usersAnswer) => usersAnswer.id === id);
     const newAnswers = [...usersAnswers];
 
-    idx !== -1 ? (newAnswers[idx] = { ...newAnswers[idx], answer }) : newAnswers.push({ id, answer });
-
+    if (option_id) {
+      idx !== -1
+        ? (newAnswers[idx] = { ...newAnswers[idx], answer, option_id })
+        : newAnswers.push({ id, answer, option_id });
+    } else {
+      idx !== -1 ? (newAnswers[idx] = { ...newAnswers[idx], answer }) : newAnswers.push({ id, answer });
+    }
+    console.log(usersAnswers);
     setUsersAnswers(newAnswers);
   };
 
@@ -92,6 +94,8 @@ const QuizTryPage = () => {
           const question = questions.find((question) => question.id === usersAnswer.id);
 
           if (question?.type === QuestionType.objective) {
+            const options = questions.find((question) => question.id === usersAnswer.id);
+
             if (usersAnswer.answer) countCorrect++;
           } else {
             if (usersAnswer.answer === question?.correct_answer) countCorrect++;
@@ -157,12 +161,12 @@ const QuizTryPage = () => {
                   className="h-[200px] object-cover rounded-md"
                 />
                 {type === QuestionType.objective ? (
-                  <Options id={id} resultMode={resultMode} onChange={handleGetAnswer} />
+                  <Options id={id} resultMode={resultMode} usersAnswer={usersAnswer} onChange={handleGetAnswer} />
                 ) : (
                   <div className="w-full relative">
                     {resultMode ? (
                       <p
-                        className={`w-full pl-4 py-[9px] border-solid border ${usersAnswer?.answer === correct_answer ? ' border-pointColor1' : 'border-pointColor2'} rounded-md`}
+                        className={`w-full pl-4 py-[9px] border-solid border ${usersAnswer?.answer === correct_answer ? ' border-pointColor1 bg-bgColor2' : 'border-pointColor2 bg-bgColor3'} rounded-md`}
                       >
                         {usersAnswer?.answer}
                       </p>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -69,10 +69,10 @@ const Header = () => {
         {/* <button onClick={toggleMenuModal}>
           <GiHamburgerMenu className="text-pointColor1" />
         </button> */}
-        <Link href="/" className="w-[10%] text-center">
+        <Link href="/" className="w-[16%] text-center">
           LOGO
         </Link>
-        <section className="w-[90%] flex justify-between px-10">
+        <section className="w-[84%] flex justify-between px-10">
           <nav className="flex gap-14">
             <Link href="/quiz-list">퀴즈</Link>
             <Link href="/typing-game">타자 연습</Link>

--- a/src/types/quizzes.ts
+++ b/src/types/quizzes.ts
@@ -42,3 +42,9 @@ export type QuestionsToInsert = Pick<Question, 'title' | 'correct_answer'> & {
   type: QuestionType;
   img_url: string;
 };
+
+export type Answer = {
+  id: string | undefined;
+  answer: string | boolean;
+  option_id?: string;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
       colors: {
         bgColor1: '#FDF8F1',
         bgColor2: '#F0F7FF',
+        bgColor3: '#FFF0EF',
         pointColor1: '#2B84ED',
         pointColor2: '#FF8878',
         blackColor: '#2e2e2e'


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-250

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 결과 페이지에서 선택형 정답/오답 조건부 렌더링
- [x] 좌측 퀴즈 정보 비율 16%로 수정(헤더 로고 부분도 늘렸는데 줄여야 할 거 같습니다..)

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- 결과모드이고 사용자가 선택한 아이디 === 옵션 아이디인 상황에서 정답/오답을 구분했습니다.
- 정답이면 파란색 배경&보더, 아니면 빨간색 배경&보더로 구분했습니다.
- 분홍색 배경이 필요해서 tailwind.config 에 추가해뒀습니다.

Options.tsx
```tsx
<div key={id} className={`pl-4 py-[9px] flex gap-4 border-solid border
  ${resultMode && usersAnswer?.option_id === id ? (is_answer ?
  'border-pointColor1 bg-bgColor2' : 'border-pointColor2 bg-bgColor3')
  : 'border-pointColor1'} rounded-md`}
>
```
![스크린샷 2024-04-10 오전 4 30 40](https://github.com/mm-easy/mm-easy/assets/142870577/54eb52bb-16eb-49b7-82d9-f1ae32cec16d)

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
![스크린샷 2024-04-10 오전 4 39 52](https://github.com/mm-easy/mm-easy/assets/142870577/5656319f-ccf9-4a53-a4cc-7f0a669afca3)