### PR TITLE
[feat] supabase SSR 방식으로 변경... 그리고 헤더 수정

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { type NextRequest } from 'next/server';
+import { updateSession } from '@/utils/supabase/middleware';
+
+export async function middleware(request: NextRequest) {
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * Feel free to modify this pattern to include more paths.
+     */
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'
+  ]
+};

--- a/src/app/(community)/community-list/page.tsx
+++ b/src/app/(community)/community-list/page.tsx
@@ -14,7 +14,7 @@ import { toast } from 'react-toastify';
 import type { Post } from '@/types/posts';
 
 const CommunityPage = () => {
-  const { getCurrentUserProfile } = useAuth();
+  // const { getCurrentUserProfile } = useAuth();
   const [post, setPost] = useState<Post[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -22,10 +22,10 @@ const CommunityPage = () => {
   const params = useSearchParams();
   const category = params.get('category');
 
-  const { data: profile } = useQuery({
-    queryKey: ['userProfile'],
-    queryFn: getCurrentUserProfile
-  });
+  // const { data: profile } = useQuery({
+  //   queryKey: ['userProfile'],
+  //   queryFn: getCurrentUserProfile
+  // });
 
   useEffect(() => {
     const postNow = async () => {
@@ -50,13 +50,13 @@ const CommunityPage = () => {
   const btnRange = 5; // 보여질 페이지 버튼의 개수
   const totalNum = post.length; // 총 데이터 수
 
-  const navigateToPostPage = () => {
-    if (!profile) {
-      toast.warn('게시물을 작성하려면 로그인 해주세요.');
-    } else {
-      router.push('/community-post');
-    }
-  };
+  // const navigateToPostPage = () => {
+  //   if (!profile) {
+  //     toast.warn('게시물을 작성하려면 로그인 해주세요.');
+  //   } else {
+  //     router.push('/community-post');
+  //   }
+  // };
 
   const indexOfLastItem = currentPage * pageRange;
   const indexOfFirstItem = indexOfLastItem - pageRange;
@@ -67,7 +67,7 @@ const CommunityPage = () => {
       <section>
         <CategorySelector categoryNow={category} />
         <div className="flex justify-center pt-64 pb-12 text-xl font-bold">
-          <CancelButton text="작성하기" onClick={navigateToPostPage} width="w-44" height='h-16' border='border-2' />
+          {/* <CancelButton text="작성하기" onClick={navigateToPostPage} width="w-44" height='h-16' border='border-2' /> */}
         </div>
       </section>
       <section className="flex w-full border-l-2 border-solid  border-pointColor1">

--- a/src/app/(main)/(components)/CommunitySection.tsx
+++ b/src/app/(main)/(components)/CommunitySection.tsx
@@ -4,64 +4,69 @@ import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 
 const CommunitySection = () => {
+  const { data: posts, isLoading } = useQuery({
+    queryKey: ['recentPosts'],
+    queryFn: getRecentPosts,
+    staleTime: 1000 * 60 * 5
+  });
 
-    const { data: posts, isLoading } = useQuery({
-        queryKey: ['recentPosts'],
-        queryFn: getRecentPosts, 
-        staleTime: 1000 * 60 * 5,
-      });
+  if (isLoading) {
+    return <div>로딩중..</div>;
+  }
 
-      if (isLoading) {
-        return <div>로딩중..</div>; 
-      }
-
-    return (
-        <>
-        <div className="p-4 text-2xl text-pointColor1 bg-bgColor1 font-bold border-y border-solid border-pointColor1">
+  return (
+    <>
+      <div className="p-4 text-2xl text-pointColor1 bg-bgColor1 font-bold border-y border-solid border-pointColor1">
         최근 올라온 글
-        </div>
-        <section className="">
+      </div>
+      <section className="">
         <div className="flex">
-        <div className="w-1/2 p-4 border-r border-solid border-pointColor1">
-        <div className='flex justify-between'>
-        <h2 className="text-lg font-bold">유저가 쓴 글</h2>
-        <Link href={`/community-list?category=전체`} className="font-semibold text-pointColor1">
-        더보기
-        </Link>
-        </div>
-        <div>
-            {posts?.map((post, index) => (
-            <div key={post.id} className={`py-4 ${index !== posts.length ? 'border-b' : ''} border-solid border-pointColor1`}>
-                <Link href={`//community-list/전체/${post.id}`}>  
+          <div className="w-1/2 p-4 border-r border-solid border-pointColor1">
+            <div className="flex justify-between">
+              <h2 className="text-lg font-bold">유저가 쓴 글</h2>
+              <Link href={`/community-list?category=전체`} className="font-semibold text-pointColor1">
+                더보기
+              </Link>
+            </div>
+            <div>
+              {posts?.map((post, index) => (
+                <div
+                  key={post.id}
+                  className={`py-4 ${index !== posts.length ? 'border-b' : ''} border-solid border-pointColor1`}
+                >
+                  <Link href={`/community-list/전체/${post.id}`}>
                     <h2 className="text-lg font-bold">{post.title}</h2>
                     <time>작성일: {formatToLocaleDateTimeString(post.created_at)}</time>
-                </Link>
+                  </Link>
+                </div>
+              ))}
             </div>
-            ))}
-        </div>
-        </div>
-        <div className="w-1/2 p-4">
-        <div className='flex justify-between'>
-        <h2 className="text-lg font-bold">유저가 쓴 글</h2>
-        <Link href={`/community-list?category=전체`} className="font-semibold text-pointColor1">
-        더보기
-        </Link>
-        </div>
-        <div>
-            {posts?.map((post, index) => (
-            <div key={post.id} className={`py-4 ${index !== posts.length ? 'border-b' : ''} border-solid border-pointColor1`}>
-                <Link href={`/community-list/전체/${post.id}`} className=''>  
+          </div>
+          <div className="w-1/2 p-4">
+            <div className="flex justify-between">
+              <h2 className="text-lg font-bold">유저가 쓴 글</h2>
+              <Link href={`/community-list?category=전체`} className="font-semibold text-pointColor1">
+                더보기
+              </Link>
+            </div>
+            <div>
+              {posts?.map((post, index) => (
+                <div
+                  key={post.id}
+                  className={`py-4 ${index !== posts.length ? 'border-b' : ''} border-solid border-pointColor1`}
+                >
+                  <Link href={`/community-list/전체/${post.id}`} className="">
                     <h2 className="text-lg font-bold">{post.title}</h2>
                     <time>작성일: {formatToLocaleDateTimeString(post.created_at)}</time>
-                </Link>
+                  </Link>
+                </div>
+              ))}
             </div>
-            ))}
+          </div>
         </div>
-        </div>
-        </div>
-        </section>
+      </section>
     </>
-    )
+  );
 };
 
 export default CommunitySection;

--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -20,6 +20,7 @@ import { storageUrl } from '@/utils/supabase/storage';
 import { handleMaxLength } from '@/utils/handleMaxLength';
 
 import { QuestionType, type Question } from '@/types/quizzes';
+import { useAuth } from '@/hooks/useAuth';
 
 const QuizForm = () => {
   const [scrollPosition, setScrollPosition] = useState<number>(0);
@@ -32,12 +33,19 @@ const QuizForm = () => {
 
   useConfirmPageLeave();
 
+  const { getCurrentUserProfile } = useAuth();
   useEffect(() => {
-    const userDataString = localStorage.getItem('sb-icnlbuaakhminucvvzcj-auth-token');
-    if (userDataString) {
-      const { user } = JSON.parse(userDataString);
-      setCurrentUser(user.email);
-    }
+    const fetchData = async () => {
+      try {
+        const userProfile = await getCurrentUserProfile();
+        if (!userProfile) return;
+        setCurrentUser(userProfile.email);
+      } catch (error) {
+        console.error('프로필 정보를 가져오는 데 실패했습니다:', error);
+      }
+    };
+
+    fetchData();
   }, []);
 
   /** 퀴즈 등록 mutation */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,9 @@ import Footer from './(main)/(components)/Footer';
 const Home = () => {
   useEffect(() => {
     const saveUserProfile = async () => {
+      const getSession = await supabase.auth.getSession();
+      console.log('세션가져오기', getSession);
+
       const userDataString = localStorage.getItem('sb-icnlbuaakhminucvvzcj-auth-token');
       if (userDataString) {
         const userData = JSON.parse(userDataString);
@@ -39,11 +42,11 @@ const Home = () => {
 
   return (
     <div className="min-h-screen">
-    <MainLogo />
-    <QuizSection/>
-    <RankingSection />
-    <CommunitySection />
-    <Footer />
+      <MainLogo />
+      <QuizSection />
+      <RankingSection />
+      <CommunitySection />
+      <Footer />
     </div>
   );
 };

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,7 +1,37 @@
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
 import MyLevelAndScore from './MyLevelAndScore';
 import MyProfile from './MyProfile';
+import { useEffect, useState } from 'react';
+import { User } from '@/types/users';
+import { useRouter } from 'next/navigation';
 
 const ProfilePage = () => {
+  const [currentUser, setCurrentUser] = useState<User | null>();
+  const { getCurrentUserProfile } = useAuth();
+  const router = useRouter();
+
+  // useEffect(() => {
+  //   const fetchData = async () => {
+  //     try {
+  //       const userProfile = await getCurrentUserProfile();
+  //       if (!userProfile) {
+  //         alert('로그인이 필요한 페이지입니다.');
+  //         router.replace('/');
+  //         return;
+  //       }
+  //       setCurrentUser(userProfile);
+  //       console.log('우우우', userProfile);
+  //       console.log('이이이', currentUser);
+  //     } catch (error) {
+  //       console.error('프로필 정보를 가져오는 데 실패했습니다:', error);
+  //     }
+  //   };
+
+  //   fetchData();
+  // }, []);
+
   return (
     <main>
       <div className="h-[47vh]">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect } from 'react';
+import { NewLifecycle, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import { useAuth } from '@/hooks/useAuth';
 import { useAtom } from 'jotai';
@@ -9,13 +9,46 @@ import { AuthChangeEvent } from '@supabase/supabase-js';
 // import { GiHamburgerMenu } from 'react-icons/gi';
 import { isLoggedInAtom, isMenuOpenAtom } from '../../store/store';
 import { supabase } from '@/utils/supabase/supabase';
+import { User } from '@/types/users';
 // import MenuPage from '@/app/menu/page';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useAtom(isMenuOpenAtom);
   const [isLoggedIn, setIsLoggedIn] = useAtom(isLoggedInAtom);
-  const { logout } = useAuth();
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const { logout, getCurrentUserProfile } = useAuth();
 
+  /** 현재 로그인되어 있는지 확인 */
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const getSession = await supabase.auth.getSession();
+        if (!getSession.data.session) {
+          return;
+        } else {
+          setIsLoggedIn(true);
+        }
+      } catch (error) {
+        console.error('프로필 정보를 가져오는 데 실패했습니다:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  /** 로그인이 되어 있다면 프로필 가져오기 */
+  useEffect(() => {
+    const fetchData = async () => {
+      if (isLoggedIn) {
+        const userProfile = await getCurrentUserProfile();
+        console.log('로그인한 자의 프로필..', userProfile);
+      }
+    };
+
+    fetchData();
+  }, [isLoggedIn]);
+
+  /** 소셜 로그인 처리 */
   useEffect(() => {
     const handleAuthStateChange = (event: AuthChangeEvent) => {
       if (event === 'SIGNED_IN') {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -159,6 +159,7 @@ export const useAuth = () => {
     }
 
     if (!userData) {
+      console.log('로그인한 사용자 없음');
       throw new Error('로그인한 사용자가 없습니다.');
     }
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,10 +2,13 @@ import { useState } from 'react';
 import { supabase } from '../utils/supabase/supabase';
 
 import type { User } from '@/types/users';
+import { useAtom } from 'jotai';
+import { isLoggedInAtom } from '@/store/store';
 
 export const useAuth = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isLoggedIn, setIsLoggedIn] = useAtom(isLoggedInAtom);
 
   const signUp = async (email: string, password: string) => {
     setLoading(true);
@@ -57,6 +60,7 @@ export const useAuth = () => {
         throw new Error(error?.message || '로그인 실패');
       }
       setLoading(false);
+      setIsLoggedIn(true);
       return true;
     } catch (error) {
       setLoading(false);
@@ -68,11 +72,13 @@ export const useAuth = () => {
 
   const logout = async () => {
     setLoading(true);
+    localStorage.clear();
     const { error } = await supabase.auth.signOut();
     if (error) {
       setError(error.message);
     } else {
       setError(null);
+      setIsLoggedIn(false);
     }
     setLoading(false);
   };
@@ -148,10 +154,12 @@ export const useAuth = () => {
     setLoading(true);
 
     const { data: userData, error: getUserError } = await supabase.auth.getUser();
-    if (getUserError || !userData.user) {
-      setError(getUserError?.message || '로그인한 사용자가 없습니다.');
-      setLoading(false);
-      return null;
+    if (getUserError) {
+      throw new Error(getUserError.message || '사용자 정보를 가져올 수 없습니다.');
+    }
+
+    if (!userData) {
+      throw new Error('로그인한 사용자가 없습니다.');
     }
 
     try {
@@ -161,7 +169,7 @@ export const useAuth = () => {
         .eq('id', userData.user.id)
         .single();
 
-      if (profileError) throw profileError;
+      if (profileError) throw new Error(profileError.message || '프로필 정보를 가져올 수 없습니다.');
 
       setLoading(false);
       return profile as User;

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,8 +1,8 @@
-import { UUID } from "crypto";
+import { UUID } from 'crypto';
 
 export type User = {
-    id:UUID;
-    email: string;
-    nickname: string;
-    avatar_img_url: string;
+  id: UUID;
+  email: string;
+  nickname: string;
+  avatar_img_url: string;
 };

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,5 +1,4 @@
 // policy 사용할 거 아니면 삭제해도 되는 파일
 
 import { createBrowserClient } from '@supabase/ssr';
-export const createClient = () =>
-  createBrowserClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
+export const createClient = (supabaseUrl: string, supabaseKey: string) => createBrowserClient(supabaseUrl, supabaseKey);

--- a/src/utils/supabase/create-client.ts
+++ b/src/utils/supabase/create-client.ts
@@ -1,5 +1,5 @@
-import 'server-only'
-import { createClient as createSupabaseClient } from '@supabase/supabase-js';
-export const createClient = () => {
-  return createSupabaseClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SECRET_KEY!, {});
-};
+// import 'server-only'
+// import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+// export const createClient = () => {
+//   return createSupabaseClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SECRET_KEY!, {});
+// };

--- a/src/utils/supabase/supabase.ts
+++ b/src/utils/supabase/supabase.ts
@@ -1,4 +1,10 @@
-import { createClient } from '@supabase/supabase-js';
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-export const supabase = createClient(supabaseUrl!, supabaseKey!);
+// import { createClient } from '@supabase/supabase-js';
+// const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+// const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+// export const supabase = createClient(supabaseUrl!, supabaseKey!);
+
+import { createClient } from './client';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-44
🔗 https://coding-legend.atlassian.net/browse/MMEASY-164

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] @supabase/ssr 에서 가져오는 `client.ts`에서 만든 createClient 사용
- [x] `create-client.ts`는 사용하지 않으므로 주석처리
- [x] 로그인 상태에 따라 Header 조건부 렌더링
- [x] 새로고침 했을 때도 로그인상태 유지하여... 일단은 조건부 렌더링

## 🧑🏻‍💻 개발 내용
* 이제 로그인을 했을 때 토큰 정보가 로컬스토리지에 저장되지 않고 쿠키에 저장됩니다. 토큰 정보를 불러올때는 `await supabase.auth.getSession()`을 사용하시면 됩니다.

## 🚨 TroubleShotting
* 세션 정보가 있는지(로그인 되어 있는 상태인지) 확인하는 코드와, 세션 정보가 있다면 profiles 테이블에서 세부 프로필 정보를 가져오는 코드를 하나의 useEffect 안에 작성하려고 했는데 어려웠습니다.
* 새로고침 시 로그인 상태 유지 이슈를 해결하면 로그아웃 시 403 forbidden 에러가 뜨고, 403 forbidden 에러를 해결하면 새로고침 시 로그인 상태가 유지되지 않아서
* 다른 의존성배열을 갖고 있는 useEffect 2개를 활용하여 로직을 나누어 해결했습니다..
* 더 좋은 아이디어 있으시면 말씀주세요..

```
/** 현재 로그인되어 있는지 확인 */
  useEffect(() => {
    const fetchData = async () => {
      try {
        const getSession = await supabase.auth.getSession();
        if (!getSession.data.session) {
          return;
        } else {
          setIsLoggedIn(true);
        }
      } catch (error) {
        console.error('프로필 정보를 가져오는 데 실패했습니다:', error);
      }
    };

    fetchData();
  }, []);

  /** 로그인이 되어 있다면 프로필 가져오기 */
  useEffect(() => {
    const fetchData = async () => {
      if (isLoggedIn) {
        const userProfile = await getCurrentUserProfile();
        console.log('로그인한 자의 프로필..', userProfile);
      }
    };

    fetchData();
  }, [isLoggedIn]);
```