### PR TITLE
[feat] 풀기 페이지에 퀴즈 작성자 정보 email => nickname 으로 변경

### DIFF
--- a/src/api/profiles.ts
+++ b/src/api/profiles.ts
@@ -1,0 +1,13 @@
+import { supabase } from '@/utils/supabase/supabase';
+
+export const getProfile = async (id: string) => {
+  try {
+    const { data, error } = await supabase.from('profiles').select('*').eq('email', id);
+    if (error) throw error;
+    return data;
+  } catch (error) {
+    console.error('프로필 데이터 받아오기 실패', error);
+    alert('일시적으로 프로필 데이터를 받아오지 못했습니다. 다시 시도하세요.');
+    throw error;
+  }
+};

--- a/src/app/(quiz)/quiz/[id]/Creator.tsx
+++ b/src/app/(quiz)/quiz/[id]/Creator.tsx
@@ -1,0 +1,34 @@
+import { getProfile } from '@/api/profiles';
+import { User } from '@/types/users';
+import { useQuery } from '@tanstack/react-query';
+
+const Creator = ({ creator }: { creator: string }) => {
+  const { data, isLoading, isError } = useQuery({
+    queryFn: async () => {
+      try {
+        const data = await getProfile(creator);
+        return data;
+      } catch (error) {
+        return error;
+      }
+    },
+    queryKey: ['profiles', creator]
+  });
+
+  if (isLoading) return <div>nickname</div>;
+  if (isError) return <div>error..</div>;
+
+  const profile = data as User[];
+  console.log(profile);
+
+  const { nickname } = profile[0];
+
+  return (
+    <div>
+      <h4>작성자</h4>
+      <p>{nickname}</p>
+    </div>
+  );
+};
+
+export default Creator;

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -14,6 +14,7 @@ import Header from './Header';
 import Options from './Options';
 
 import { QuestionType, type GetQuiz, type Question, type Answer } from '@/types/quizzes';
+import Creator from './Creator';
 
 const QuizTryPage = () => {
   const { id } = useParams();
@@ -55,11 +56,8 @@ const QuizTryPage = () => {
     queryKey: ['questions']
   });
 
-  if (quizIsLoading) return <div>퀴즈 로드 중..</div>;
-  if (quizIsError) return <div>퀴즈 로드 에러..</div>;
-
-  if (questionsIsLoading) return <div>퀴즈 로드 중..</div>;
-  if (questionsIsError) return <div>퀴즈 로드 에러..</div>;
+  if (quizIsLoading || questionsIsLoading) return <div>로드 중..</div>;
+  if (quizIsError || questionsIsError) return <div>에러..</div>;
 
   const quizzes = quizData as GetQuiz[];
   const { title, level, info, thumbnail_img_url: url, creator_id, created_at } = quizzes[0];
@@ -129,10 +127,7 @@ const QuizTryPage = () => {
               className="w-full h-[230px] object-cover border-solid border-b-2 border-pointColor1"
             />
             <section className="p-4 flex flex-col gap-4 border-solid border-b-2 border-pointColor1">
-              <div>
-                <h4>작성자</h4>
-                <p>{creator_id}</p>
-              </div>
+              <Creator creator={creator_id} />
               <div>
                 <h4>등록일</h4>
                 <p>{formatToLocaleDateTimeString(created_at)}</p>


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-242

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 풀기 페이지에 퀴즈 작성자 정보 email => nickname 으로 변경

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- creator 이메일을 받아 profiles 테이블에서 닉네임 가져왔습니다.
- 같은 닉네임이 계속 표시됐었는데 쿼리키에 creator 추가해서 해결했습니다.

Creator.tsx
```tsx
const Creator = ({ creator }: { creator: string }) => {
  const { data, isLoading, isError } = useQuery({
    queryFn: async () => {
      try {
        const data = await getProfile(creator);
        return data;
      } catch (error) {
        return error;
      }
    },
    queryKey: ['profiles', creator]
  });
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
- 쿼리키 수정 전
<img width="195" alt="스크린샷 2024-04-11 오후 6 08 39" src="https://github.com/mm-easy/mm-easy/assets/142870577/a34d5fad-d6c3-4fe4-a6c1-d6546fea536e">

- 쿼리키 수정 후
<img width="195" alt="스크린샷 2024-04-11 오후 6 16 49" src="https://github.com/mm-easy/mm-easy/assets/142870577/ee8e5465-1f86-4cb9-81ed-e30f5b665d7f">


## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
- 풀기 페이지를 들어가면 잠깐 다른 문제가 뜨고 있네요..
