### PR TITLE
[fix] 퀴즈 풀기 페이지 로그인 확인 & 프로필 요청 useEffect 분리, 의존성 배열 수정

### DIFF
--- a/src/api/tries.ts
+++ b/src/api/tries.ts
@@ -12,7 +12,7 @@ export const insertQuizTry = async (quizTries: QuizTry) => {
   }
 };
 
-export const updateQuizScore = async (userId: string, quizId: string | string[], score: number) => {
+export const updateQuizScore = async (userId: string | null, quizId: string | string[], score: number) => {
   try {
     const { error } = await supabase.from('quiz_tries').update({ score }).eq('user_id', userId).eq('quiz_id', quizId);
     if (error) throw error;

--- a/src/app/(quiz)/quiz/[id]/Creator.tsx
+++ b/src/app/(quiz)/quiz/[id]/Creator.tsx
@@ -3,25 +3,25 @@ import { User } from '@/types/users';
 import { useQuery } from '@tanstack/react-query';
 
 const Creator = ({ creator }: { creator: string }) => {
-  // const { data, isLoading, isError } = useQuery({
-  //   queryFn: async () => {
-  //     try {
-  //       const data = await getProfile(creator);
-  //       return data;
-  //     } catch (error) {
-  //       return error;
-  //     }
-  //   },
-  //   queryKey: ['profiles', creator]
-  // });
+  const { data, isLoading, isError } = useQuery({
+    queryFn: async () => {
+      try {
+        const data = await getProfile(creator);
+        return data;
+      } catch (error) {
+        return error;
+      }
+    },
+    queryKey: ['profiles', creator]
+  });
 
-  // if (isLoading) return <div>nickname</div>;
-  // if (isError) return <div>error..</div>;
+  if (isLoading) return <div>nickname</div>;
+  if (isError) return <div>error..</div>;
 
-  // const profile = data as User[];
-  // console.log(profile);
+  const profile = data as User[];
+  console.log(profile);
 
-  // const { nickname } = profile[0];
+  const { nickname } = profile[0];
 
   return (
     <div>

--- a/src/types/quizzes.ts
+++ b/src/types/quizzes.ts
@@ -50,8 +50,8 @@ export type Answer = {
 };
 
 export type QuizTry = {
+  user_id: string | null;
   quiz_id: string | string[];
-  user_id: string;
   score: number;
 };
 


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-282
🔗 https://coding-legend.atlassian.net/browse/MMEASY-281

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 로그인 확인 & 프로필 요청 useEffect 분리
- [x] 무한 요청되고 있던 프로필 api 의존성 배열 수정해서 해결

## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
Header.tsx
![스크린샷 2024-04-12 오전 12 53 13](https://github.com/mm-easy/mm-easy/assets/142870577/ba79fd54-e3b2-48e1-a2e3-de197c31d1ff)
useAuth.tsx
![스크린샷 2024-04-12 오전 12 52 25](https://github.com/mm-easy/mm-easy/assets/142870577/0e5ef35c-b9cd-4141-9e07-2634f888a037)

프로필이 없을 때 그냥 return 이 아닌 return null 으로 설정하신게 궁금합니다. 😲
없는 값인 걸 확실히 하는걸까요?