### PR TITLE
[fix] 사용자가 이미지를 등록하지 않은 question 은 기본 이미지도 표시 X

### DIFF
--- a/src/app/(quiz)/quiz/[id]/Creator.tsx
+++ b/src/app/(quiz)/quiz/[id]/Creator.tsx
@@ -19,15 +19,13 @@ const Creator = ({ creator }: { creator: string }) => {
   if (isError) return <div>error..</div>;
 
   const profile = data as User[];
-  console.log(profile);
 
   const { nickname } = profile[0];
 
   return (
     <div>
       <h4>작성자</h4>
-      {/* <p>{nickname}</p> */}
-      <p>nickname</p>
+      <p>{nickname}</p>
     </div>
   );
 };

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -207,13 +207,17 @@ const QuizTryPage = () => {
             return (
               <section key={id} className="w-[570px] flex flex-col place-items-center gap-4">
                 <h3 className="self-start text-lg">{`${questions.indexOf(question) + 1}. ${title}`}</h3>
-                <Image
-                  src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/question-imgs/${img_url}`}
-                  alt="문제 이미지"
-                  width={570}
-                  height={200}
-                  className="h-[200px] object-cover rounded-md"
-                />
+                {img_url !== 'tempThumbnail.png' ? (
+                  <Image
+                    src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/question-imgs/${img_url}`}
+                    alt="문제 이미지"
+                    width={570}
+                    height={200}
+                    className="h-[200px] object-cover rounded-md"
+                  />
+                ) : (
+                  <></>
+                )}
                 {type === QuestionType.objective ? (
                   <Options id={id} resultMode={resultMode} usersAnswer={usersAnswer} onChange={handleGetAnswer} />
                 ) : (


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-270

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 등록된 이미지가 없는 question 은 이미지 영역이 표시되지 않게 수정

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- 가져온 question 의 img_url 이 기본 이미지명이랑 같다면 표시되지 않게 했습니다.

quiz/[id]/page.tsx
```tsx
{img_url !== 'tempThumbnail.png' ? (
  <Image
    src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/question-imgs/${img_url}`}
    alt="문제 이미지"
    width={570}
    height={200}
    className="h-[200px] object-cover rounded-md"
  />
) : (
  <></>
)}
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
<img width="840" alt="스크린샷 2024-04-12 오전 1 07 09" src="https://github.com/mm-easy/mm-easy/assets/142870577/63ebde3e-db1a-4ecf-8603-60402e81e582">
<img width="840" alt="스크린샷 2024-04-12 오전 1 07 38" src="https://github.com/mm-easy/mm-easy/assets/142870577/ec8d6a27-0ea6-45a6-95f0-e6e52d313705">