### PR TITLE
[style] quiz-form 페이지 파일첨부 이전 기본이미지 적용

### DIFF
--- a/src/app/(quiz)/(components)/QuestionForm.tsx
+++ b/src/app/(quiz)/(components)/QuestionForm.tsx
@@ -156,7 +156,7 @@ const QuestionForm = ({
     setQuestions((prev) =>
       prev.map((question) => {
         return question.id === id
-          ? { ...question, img_url: `${storageUrl}/quiz-thumbnails/tempThumbnail.png`, img_file: null }
+          ? { ...question, img_url: `${storageUrl}/assets/quiz_570x160.png`, img_file: null }
           : question;
       })
     );
@@ -225,7 +225,7 @@ const QuestionForm = ({
                               handleChangeOption(id, e.target.value, options, option.id);
                             }}
                           />
-                          <p className="absolute top-0 right-2 pt-3 pr-1 text-sm">{option.content.length}/25</p>
+                          <p className="absolute top-0 right-2 pt-3 pr-1 text-sm">{option.content.length} / 25</p>
                         </div>
                         <button
                           type="button"
@@ -239,7 +239,7 @@ const QuestionForm = ({
                   })}
                   <button
                     type="button"
-                    className="w-full pb-[6px] text-3xl border-solid border border-pointColor1 rounded-md"
+                    className="w-full text-3xl border-solid border border-pointColor1 rounded-md"
                     onClick={() => handleAddOption(id, options)}
                   >
                     +

--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -6,6 +6,8 @@ import PlusQuestionBtn from './PlusQuestionBtn';
 import PageUpBtn from '@/components/common/PageUpBtn';
 import useConfirmPageLeave from '@/hooks/useConfirmPageLeave';
 import UnloadImgBtn from './UnloadImg';
+import default144 from '@/assets/quiz_144x144.png';
+import default570 from '@/assets/quiz_570x160.png';
 
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -27,7 +29,7 @@ const QuizForm = () => {
   const [level, setLevel] = useState<number>(0);
   const [title, setTitle] = useState('');
   const [info, setInfo] = useState('');
-  const [selectedImg, setSelectedImg] = useState(`${storageUrl}/quiz-thumbnails/tempThumbnail.png`);
+  const [selectedImg, setSelectedImg] = useState(`${storageUrl}/assets/quiz_144x144.png`);
   const [file, setFile] = useState<File | null>(null);
   const [currentUser, setCurrentUser] = useState('');
   const { getCurrentUserProfile } = useAuth();
@@ -62,7 +64,7 @@ const QuizForm = () => {
       type: QuestionType.objective,
       title: '',
       img_file: null,
-      img_url: `${storageUrl}/quiz-thumbnails/tempThumbnail.png`,
+      img_url: `${storageUrl}/assets/quiz_570x160.png`,
       correct_answer: '',
       options: [
         {
@@ -82,7 +84,7 @@ const QuizForm = () => {
       type: QuestionType.objective,
       title: '',
       img_file: null,
-      img_url: `${storageUrl}/quiz-thumbnails/tempThumbnail.png`,
+      img_url: `${storageUrl}/assets/quiz_570x160.png`,
       correct_answer: '',
       options: [
         {
@@ -159,7 +161,7 @@ const QuizForm = () => {
             }
           ],
           img_file: null,
-          img_url: `${storageUrl}/quiz-thumbnails/tempThumbnail.png`,
+          img_url: `${storageUrl}/assets/quiz_570x160.png`,
           correct_answer: ''
         }
       ]);
@@ -268,7 +270,7 @@ const QuizForm = () => {
   const handleRemoveImg = (e: React.MouseEvent<HTMLSpanElement>) => {
     e.stopPropagation();
     setFile(null);
-    setSelectedImg(`${storageUrl}/quiz-thumbnails/tempThumbnail.png`);
+    setSelectedImg(`${storageUrl}/assets/quiz_144x144.png`);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }

--- a/src/components/common/BlueInput.tsx
+++ b/src/components/common/BlueInput.tsx
@@ -70,7 +70,7 @@ export const BlueLevelSelect: React.FC<BlueLevelSelectProps> = ({ value, onChang
           value === 1 ? 'bg-pointColor1 text-white' : 'bg-white text-pointColor1'
         }`}
       >
-        꼬마급
+        순한맛
       </label>
       <input
         type="radio"
@@ -87,7 +87,7 @@ export const BlueLevelSelect: React.FC<BlueLevelSelectProps> = ({ value, onChang
           value === 2 ? 'bg-pointColor1 text-white' : 'bg-white text-pointColor1'
         }`}
       >
-        똑똑이급
+        중간맛
       </label>
       <input
         type="radio"
@@ -104,7 +104,7 @@ export const BlueLevelSelect: React.FC<BlueLevelSelectProps> = ({ value, onChang
           value === 3 ? 'bg-pointColor1 text-white' : 'bg-white text-pointColor1'
         }`}
       >
-        대장급
+        매운맛
       </label>
     </div>
   );

--- a/src/components/common/SubHeader.tsx
+++ b/src/components/common/SubHeader.tsx
@@ -4,7 +4,7 @@ interface QuizFormHeaderProps {
 
 const SubHeader: React.FC<QuizFormHeaderProps> = ({ text }) => {
   return (
-    <main className="h-[8vh] font-bold pl-10 leading-[8vh] bg-bgColor1 border-b-2 border-pointColor1 text-pointColor1">
+    <main className="h-[8vh] font-bold pl-20 leading-[8vh] bg-bgColor1 border-b-2 border-pointColor1 text-pointColor1">
       {text}
     </main>
   );


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-368

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 파일 첨부하기 전에 기본으로 출력되는 이미지를 설정했습니다
- [x] 순한맛/중간맛/매운맛 텍스트 수정
- [x] 파일 첨부하지 않을 시 기본 썸네일만 설정하면 끝날 것 같습니다

## 📸 스크린샷(선택)
![image](https://github.com/mm-easy/mm-easy/assets/153061626/a0e87774-2160-4194-b46c-be7608aebbed)
