### PR TITLE
[style] quiz-form 랜덤 기본 썸네일 지정, quiz-list 퀴즈 배열 수정

### DIFF
--- a/src/api/quizzes.ts
+++ b/src/api/quizzes.ts
@@ -80,9 +80,10 @@ export const insertOptionsToTable = async (newOptions: OptionsToInsert[]) => {
   }
 };
 
+/** quizzes 테이블에서 전체 데이터 가져오기 */
 export const getQuizzes = async () => {
   try {
-    const { data, error } = await supabase.from('quizzes').select('*');
+    const { data, error } = await supabase.from('quizzes').select('*').order('created_at', { ascending: false });
     if (error) throw error;
     return data;
   } catch (error) {

--- a/src/app/(main)/(components)/QuestionEx.tsx
+++ b/src/app/(main)/(components)/QuestionEx.tsx
@@ -2,8 +2,8 @@ import { getExQuestion } from '@/api/questions';
 import { useQuery } from '@tanstack/react-query';
 import type { Question } from '@/types/quizzes';
 
-const QuestionEx = ({id}:{id:string|undefined}) => {
-  const { data , isLoading } = useQuery({
+const QuestionEx = ({ id }: { id: string | undefined }) => {
+  const { data, isLoading } = useQuery({
     queryFn: async () => {
       try {
         const data = await getExQuestion(id);
@@ -15,14 +15,14 @@ const QuestionEx = ({id}:{id:string|undefined}) => {
     queryKey: ['questions', id]
   });
 
-  if(isLoading){return <div>로딩 중..</div>}
+  if (isLoading) {
+    return <div>로딩 중..</div>;
+  }
 
   const question = data as Question[];
-  const {title} = question[0]
+  const { title } = question[0];
 
-  return (
-    <div>{title}</div>
-  )
-}
+  return <div className="truncate">{title}</div>;
+};
 
 export default QuestionEx;

--- a/src/app/(main)/(components)/QuizSection.tsx
+++ b/src/app/(main)/(components)/QuizSection.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import type { Quiz } from '@/types/quizzes';
+import { storageUrl } from '@/utils/supabase/storage';
 
 const QuizSection = () => {
   const { data: quiz, isLoading } = useQuery<Quiz[]>({
@@ -23,8 +24,8 @@ const QuizSection = () => {
         <div className="flex items-center justify-center">
           <p className="w-5/6 ml-10">최근 올라온 퀴즈</p>
           <Link href={`/quiz-list`} className="mr-10 font-semibold text-lg text-pointColor1">
-                더보기
-              </Link>
+            더보기
+          </Link>
         </div>
       </div>
       <section className="flex flex-col justify-center items-center">
@@ -34,10 +35,10 @@ const QuizSection = () => {
               key={quiz.id}
               className="flex flex-col border my-5 border-solid border-gray-200 rounded-t-3xl rounded-b-md p-4"
             >
-              <p className="font-bold text-lg mt-4 mb-3">{quiz.title}</p>
+              <p className="font-bold text-lg mt-4 mb-3 truncate">{quiz.title}</p>
               <div className="flex flex-col gap-3">
                 <Image
-                  src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/${quiz.thumbnail_img_url}`}
+                  src={`${storageUrl}/quiz-thumbnails/${quiz.thumbnail_img_url}`}
                   alt="퀴즈 썸네일"
                   width={250}
                   height={250}

--- a/src/app/(quiz)/(components)/QuizForm.tsx
+++ b/src/app/(quiz)/(components)/QuizForm.tsx
@@ -23,6 +23,7 @@ import { handleMaxLength } from '@/utils/handleMaxLength';
 import { QuestionType, type Question } from '@/types/quizzes';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/utils/supabase/supabase';
+import { getRandomThumbnail } from '@/utils/getRandomThumbnail';
 
 const QuizForm = () => {
   const [scrollPosition, setScrollPosition] = useState<number>(0);
@@ -225,7 +226,7 @@ const QuizForm = () => {
         level,
         title,
         info,
-        thumbnail_img_url: imgUrl || 'tempThumbnail.png'
+        thumbnail_img_url: imgUrl || getRandomThumbnail()
       };
 
       const insertQuizResult = await insertQuizMutation.mutateAsync(newQuiz);

--- a/src/app/(quiz)/(components)/QuizList.tsx
+++ b/src/app/(quiz)/(components)/QuizList.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import RecommendLoginModal from '@/components/common/RecommendLoginModal';
 import { useEffect, useState } from 'react';
 import PageUpBtn from '@/components/common/PageUpBtn';
+import { storageUrl } from '@/utils/supabase/storage';
 
 const QuizList = ({ quizLevelSelected, currentUser }: { quizLevelSelected: Quiz[]; currentUser: string }) => {
   const router = useRouter();
@@ -53,13 +54,14 @@ const QuizList = ({ quizLevelSelected, currentUser }: { quizLevelSelected: Quiz[
           >
             <p className="font-bold text-lg mt-4 mb-3">{item.title}</p>
             <div className="flex flex-col gap-3">
-              <div className="border-solid border border-pointColor1 rounded-md overflow-hidden w-[250px] h-[250px]">
+              <div className="border-solid border-2 border-pointColor1 rounded-md overflow-hidden w-[250px] h-[250px]">
                 <Image
-                  src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/${item.thumbnail_img_url}`}
+                  src={`${storageUrl}/quiz-thumbnails/${item.thumbnail_img_url}`}
                   alt="퀴즈 썸네일"
                   width={250}
                   height={250}
-                  className="w-full h-[250px] object-cover border-solid border border-pointColor1 rounded-md"
+                  quality={100}
+                  className="w-full h-[250px] object-cover"
                 />
               </div>
               <p className="mb-4">{item.info}</p>

--- a/src/app/(quiz)/(components)/QuizList.tsx
+++ b/src/app/(quiz)/(components)/QuizList.tsx
@@ -41,30 +41,28 @@ const QuizList = ({ quizLevelSelected, currentUser }: { quizLevelSelected: Quiz[
   };
 
   return (
-    <main className="p-5 flex flex-col items-center">
+    <main className="p-5 flex flex-col justify-center items-center">
       {quizLevelSelected.length === 0 && <div className="p-36">해당 난이도에 아직 등록된 퀴즈가 없습니다.</div>}
-      <div className="w-full grid grid-cols-4 place-items-center gap-4">
+      <div className="w-9/12 grid grid-cols-4 gap-10 p-4">
         {quizLevelSelected.map((item) => (
           <div
             key={item.id}
-            className="flex flex-col border my-5 border-solid border-gray-200 rounded-t-3xl rounded-b-md p-4 min-w-[250px] cursor-pointer"
+            className="flex flex-col border my-3 border-solid border-gray-200 rounded-t-3xl rounded-b-md p-4 cursor-pointer"
             onClick={() => {
               handleShowModal(item.id);
             }}
           >
-            <p className="font-bold text-lg mt-4 mb-3">{item.title}</p>
+            <p className="font-bold text-lg mt-4 mb-3 truncate">{item.title}</p>
             <div className="flex flex-col gap-3">
-              <div className="border-solid border-2 border-pointColor1 rounded-md overflow-hidden w-[250px] h-[250px]">
-                <Image
-                  src={`${storageUrl}/quiz-thumbnails/${item.thumbnail_img_url}`}
-                  alt="퀴즈 썸네일"
-                  width={250}
-                  height={250}
-                  quality={100}
-                  className="w-full h-[250px] object-cover"
-                />
-              </div>
-              <p className="mb-4">{item.info}</p>
+              <Image
+                src={`${storageUrl}/quiz-thumbnails/${item.thumbnail_img_url}`}
+                alt="퀴즈 썸네일"
+                width={250}
+                height={250}
+                quality={100}
+                className="w-full h-[250px] object-cover border-solid border-2 border-pointColor1 rounded-md"
+              />
+              <p className="mb-4 line-clamp-2">{item.info}</p>
             </div>
           </div>
         ))}

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -20,6 +20,7 @@ import Options from './Options';
 import { QuestionType, type Question, Answer, Quiz } from '@/types/quizzes';
 import { errorMonitor } from 'events';
 import PageUpBtn from '@/components/common/PageUpBtn';
+import { storageUrl } from '@/utils/supabase/storage';
 
 const QuizTryPage = () => {
   const { id } = useParams();
@@ -202,10 +203,11 @@ const QuizTryPage = () => {
         <article className="h-[76vh] text-pointColor1">
           <section>
             <Image
-              src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/quiz-thumbnails/${url}`}
+              src={`${storageUrl}/quiz-thumbnails/${url}`}
               alt="샘플 이미지"
               width={230}
               height={230}
+              quality={100}
               className="w-full h-[230px] object-cover border-solid border-b-2 border-pointColor1"
             />
             <section className="p-4 flex flex-col gap-4 border-solid border-b-2 border-pointColor1">
@@ -232,7 +234,7 @@ const QuizTryPage = () => {
                 <h3 className="self-start text-lg">{`${questions.indexOf(question) + 1}. ${title}`}</h3>
                 {img_url !== 'tempThumbnail.png' ? (
                   <Image
-                    src={`https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/question-imgs/${img_url}`}
+                    src={`${storageUrl}/question-imgs/${img_url}`}
                     alt="문제 이미지"
                     width={570}
                     height={200}
@@ -247,7 +249,11 @@ const QuizTryPage = () => {
                   <div className="w-full relative">
                     {resultMode ? (
                       <p
-                        className={`w-full pl-4 py-[9px] border-solid border ${usersAnswer?.answer === correct_answer ? ' border-pointColor1 bg-bgColor2' : 'border-pointColor2 bg-bgColor3'} rounded-md`}
+                        className={`w-full pl-4 py-[9px] border-solid border ${
+                          usersAnswer?.answer === correct_answer
+                            ? ' border-pointColor1 bg-bgColor2'
+                            : 'border-pointColor2 bg-bgColor3'
+                        } rounded-md`}
                       >
                         {usersAnswer?.answer}
                       </p>

--- a/src/utils/getRandomThumbnail.ts
+++ b/src/utils/getRandomThumbnail.ts
@@ -1,0 +1,5 @@
+export const getRandomThumbnail = (): string => {
+  const thumbnails = ['quiz_thumb_1.png', 'quiz_thumb_2.png', 'quiz_thumb_3.png'];
+  const randomIndex = Math.floor(Math.random() * thumbnails.length);
+  return thumbnails[randomIndex];
+};


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-370
🔗 https://coding-legend.atlassian.net/browse/MMEASY-371

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] quiz-list 페이지 브라우저 너비가 좁아지면 퀴즈끼리 겹치던 현상 수정
- [x] quiz-form 썸네일 선택 안하면 기본 썸네일 3개 중 랜덤으로 하나 삽입

## 🧑🏻‍💻 개발 내용
썸네일 이미지 주소가 들어 있는 배열을 만들어서 랜덤 인덱스를 추출하는 함수를 만들었습니다
```ts
export const getRandomThumbnail = (): string => {
  const thumbnails = ['quiz_thumb_1.png', 'quiz_thumb_2.png', 'quiz_thumb_3.png'];
  const randomIndex = Math.floor(Math.random() * thumbnails.length);
  return thumbnails[randomIndex];
};
```
첨부한 이미지가 없을때(imgUrl === null) 위의 함수를 실행시켜 랜덤 이미지 주소를 얻습니다
```tsx
      // newQuiz 구성하여 quizzes 테이블에 인서트
      const newQuiz = {
        creator_id: currentUser,
        level,
        title,
        info,
        thumbnail_img_url: imgUrl || getRandomThumbnail()
      };

      const insertQuizResult = await insertQuizMutation.mutateAsync(newQuiz);
```