### PR TITLE
[feat] 메인페이지 공지 표시

### DIFF
--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -21,6 +21,21 @@ export const getRecentPosts = async () => {
   const { data: posts, error } = await supabase
     .from('posts')
     .select('*')
+    .neq('category', '공지') 
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false }) // 최신 게시글부터 정렬
+    .limit(3); // 3개의 게시글만 가져옴
+
+  if (error) throw error;
+  return posts || [];
+};
+
+export const getRecentNotice = async () => {
+  const { data: posts, error } = await supabase
+    .from('posts')
+    .select('*')
+    .eq('category', '공지') 
+    .is('deleted_at', null)
     .order('created_at', { ascending: false }) // 최신 게시글부터 정렬
     .limit(3); // 3개의 게시글만 가져옴
 

--- a/src/app/(community)/(components)/CommunityForm.tsx
+++ b/src/app/(community)/(components)/CommunityForm.tsx
@@ -32,7 +32,7 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
   const endPage = Math.min(startPage + btnRange - 1, Math.ceil(totalNum / pageRange));
 
   return (
-    <article className="w-full">
+    <article className="w-full ">
       <div className="bg-white p-4 w-full">
         <table className="w-full">
           <thead className="text-left">
@@ -48,7 +48,7 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
             {currentItems?.length > 0 ? (
               currentItems.map((item, idx) => (
                 <tr
-                  className="bg-white cursor-pointer border-y border-solid border-pointColor3"
+                  className={`bg-white cursor-pointer border-y border-solid border-pointColor3 text-[calc(1vh+5px)] ${item['category'] === '공지' ? 'font-bold' : ''}`}
                   key={idx}
                   onClick={() => navigateToDetailPost(item)}
                 >

--- a/src/app/(main)/(components)/CommunitySection.tsx
+++ b/src/app/(main)/(components)/CommunitySection.tsx
@@ -1,16 +1,23 @@
 import { formatToLocaleDateTimeString } from '@/utils/date';
-import { getRecentPosts } from '@/api/posts';
+import { getRecentPosts, getRecentNotice } from '@/api/posts';
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 
-const CommunitySection = () => {
-  const { data: posts, isLoading } = useQuery({
-    queryKey: ['recentPosts'],
-    queryFn: getRecentPosts,
-    staleTime: 1000 * 60 * 5
+  const CommunitySection = () => {
+
+    const { data: posts, isLoading: postsLoading } = useQuery({
+      queryKey: ['recentPosts'],
+      queryFn: getRecentPosts,
+      staleTime: 1000 * 60 * 5
   });
 
-  if (isLoading) {
+    const { data: notices, isLoading: noticesLoading } = useQuery({
+      queryKey: ['recentNotice'],
+      queryFn: getRecentNotice,
+      staleTime: 1000 * 60 * 5
+    });
+
+  if (postsLoading || noticesLoading) {
     return <div>로딩중..</div>;
   }
 
@@ -31,14 +38,14 @@ const CommunitySection = () => {
               </Link>
             </div>
             <div>
-              {posts?.map((post, index) => (
+              {notices?.map((notice, index) => (
                 <div
-                  key={post.id}
-                  className={`py-4 ${index !== posts.length - 1 && 'border-b border-solid border-pointColor1'}`}
+                  key={notice.id}
+                  className={`py-4 ${index !== notices.length - 1 && 'border-b border-solid border-pointColor1'}`}
                 >
-                  <Link href={`/community-list/전체/${post.id}`} className="flex flex-col gap-2">
-                    <h2 className="text-lg font-bold truncate">{post.title}</h2>
-                    <time>작성일: {formatToLocaleDateTimeString(post.created_at)}</time>
+                  <Link href={`/community-list/전체/${notice.id}`} className="flex flex-col gap-2">
+                    <h2 className="text-lg font-bold truncate">{notice.title}</h2>
+                    <time>작성일: {formatToLocaleDateTimeString(notice.created_at)}</time>
                   </Link>
                 </div>
               ))}


### PR DESCRIPTION
## 📍 관련 이슈

🔗 https://coding-legend.atlassian.net/browse/MMEASY-399

## ✍️ Task TODOLIST

- [x] 메인페이지 공지 표시

## 🧑🏻‍💻 개발 내용

```
export const getRecentPosts = async () => {
  const { data: posts, error } = await supabase
    .from('posts')
    .select('*')
    .neq('category', '공지')  // category가 공지가 아닌것만
    .is('deleted_at', null). // deleted_at이 null 인것만
    .order('created_at', { ascending: false }) // 최신 게시글부터 정렬
    .limit(3); // 3개의 게시글만 가져옴

export const getRecentNotice = async () => {
  const { data: posts, error } = await supabase
    .from('posts')
    .select('*')
    .eq('category', '공지')  // category가 공지 인것만
    .is('deleted_at', null)  // deleted_at이 null 인것만
    .order('created_at', { ascending: false }) // 최신 게시글부터 정렬
    .limit(3); // 3개의 게시글만 가져옴
```

## 📸 스크린샷(선택)

![Screen Shot 2024-04-15 at 10 58 50 AM](https://github.com/mm-easy/mm-easy/assets/153264541/fe8871d7-38c8-4ae7-81b1-683684be8289)

