### PR TITLE
[feat] 관리자 페이지 조건부 랜더링 및 나의 활동 오류수정

### DIFF
--- a/src/api/quizzes.ts
+++ b/src/api/quizzes.ts
@@ -137,7 +137,13 @@ export const getQuizRank = async (): Promise<QuizRank[]> => {
 
 export const fetchUserQuizzes = async (email: string) => {
   try {
-    const { data, error } = await supabase.from('quizzes').select(`*,quiz_tries:id (id)`).eq('creator_id', email);
+    const { data, error } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        quiz_tries:quiz_tries!public_quiz_tries_quiz_id_fkey(id)
+      `)
+      .eq('creator_id', email);
 
     if (error) throw error;
     return data;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -40,7 +40,7 @@ const AdminPage = () => {
 
   // 에러가 발생했거나 로그인한 사용자가 없거나 특정 이메일이 아닐 경우 로그인 페이지로 리다이렉트
   if (isProfileError || !userProfile || userProfile.email !== 'daejang@mmeasy.com') {
-    router.push("/login");
+    router.push("/");
     alert('접근할 수 없습니다.');
   }
 
@@ -96,7 +96,9 @@ const AdminPage = () => {
 
   return (
     <article className="w-full p-40 bg-bgColor2">
-      <nav className="flex px-4 justify-center text-pointColor1 font-medium  border-solid border-pointColor1 pb-16 cursor-pointer">
+      {userProfile?.email === 'daejang@mmeasy.com' && (
+        <>
+        <nav className="flex px-4 justify-center text-pointColor1 font-medium  border-solid border-pointColor1 pb-16 cursor-pointer">
         <ul className="flex justify-center text-2xl w-full text-center border-b-2 border-solid ">
           <li
             className={`w-[50%] pb-6 ${activeTab === 'posts' ? 'font-bold border-solid border-b-3' : ''}`}
@@ -172,6 +174,8 @@ const AdminPage = () => {
           )}
         </table>
       </div>
+        </>
+      )}
     </article>
   );
 };

--- a/src/app/my-activity/MyActivity.tsx
+++ b/src/app/my-activity/MyActivity.tsx
@@ -192,29 +192,29 @@ const MyActivity = () => {
               </tr>
             </thead>
             <tbody>
-              {currentSolvedQuizzes && currentSolvedQuizzes.length > 0
-                ? currentSolvedQuizzes.map((quiz, index) => (
-                    <tr className="bg-white border-b border-solid border-pointColor3" key={index}>
-                      <td className="py-4 w-24">{quiz.quizzes.title}</td>
-                      <td>{quiz.score}</td>
-                      <td>{formatToLocaleDateTimeString(quiz.created_at)}</td>
-                      <div className="text-right">
-                        <button
-                          className="h-8 w-28 border border-solid border-pointColor1 px-4 rounded-md font-bold text-pointColor1"
-                          onClick={() => navigateToQuiz(quiz)}
-                        >
-                          다시 풀기
-                        </button>
-                      </div>
-                    </tr>
-                  ))
-                  : (
-                    <tr>
-                      <td colSpan={4} className="text-center py-6 text-pointColor1 font-bold text-lg">
-                        푼 퀴즈가 없습니다.
-                      </td>
-                    </tr>
-                  )}
+              {currentSolvedQuizzes && currentSolvedQuizzes.length > 0 ? (
+                currentSolvedQuizzes.map((quiz, index) => (
+                  <tr className="bg-white border-b border-solid border-pointColor3" key={index}>
+                    <td className="py-4 w-24">{quiz.quizzes.title}</td>
+                    <td>{quiz.score}</td>
+                    <td>{formatToLocaleDateTimeString(quiz.created_at)}</td>
+                    <div className="text-right">
+                      <button
+                        className="h-8 w-28 border border-solid border-pointColor1 px-4 rounded-md font-bold text-pointColor1"
+                        onClick={() => navigateToQuiz(quiz)}
+                      >
+                        다시 풀기
+                      </button>
+                    </div>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={4} className="text-center py-6 text-pointColor1 font-bold text-lg">
+                    푼 퀴즈가 없습니다.
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>
@@ -231,31 +231,31 @@ const MyActivity = () => {
               </tr>
             </thead>
             <tbody>
-              {currentQuizzes && currentQuizzes.length > 0
-                ? currentQuizzes.map((quiz, index) => (
-                    <tr className="bg-white border-b border-solid border-pointColor3" key={index}>
-                      <td className="py-4 w-24">
-                        <a href={`/quiz/${quiz.id}`}>{quiz.title}</a>
-                      </td>
-                      <td>{quiz.quiz_tries.length}</td>
-                      <td>{formatToLocaleDateTimeString(quiz.created_at)}</td>
-                      <div className="text-right">
-                        <button
-                          className="h-8 w-28 border border-solid border-pointColor1 px-4 rounded-md font-bold text-pointColor1"
-                          onClick={() => navigateToQuiz(quiz.id)}
-                        >
-                          다시 풀기
-                        </button>
-                      </div>
-                    </tr>
-                  ))
-                  : (
-                    <tr>
-                      <td colSpan={4} className="text-center py-6 text-pointColor1 font-bold text-lg">
-                        만든 퀴즈가 없습니다.
-                      </td>
-                    </tr>
-                  )}
+              {currentQuizzes && currentQuizzes.length > 0 ? (
+                currentQuizzes.map((quiz, index) => (
+                  <tr className="bg-white border-b border-solid border-pointColor3" key={index}>
+                    <td className="py-4 w-24">
+                      <a href={`/quiz/${quiz.id}`}>{quiz.title}</a>
+                    </td>
+                    <td>{quiz.quiz_tries.length}</td>
+                    <td>{formatToLocaleDateTimeString(quiz.created_at)}</td>
+                    <div className="text-right">
+                      <button
+                        className="h-8 w-28 border border-solid border-pointColor1 px-4 rounded-md font-bold text-pointColor1"
+                        onClick={() => navigateToQuiz(quiz.id)}
+                      >
+                        다시 풀기
+                      </button>
+                    </div>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={4} className="text-center py-6 text-pointColor1 font-bold text-lg">
+                    만든 퀴즈가 없습니다.
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -204,3 +204,4 @@ export const useAuth = () => {
 
   return { signUp, signIn, logout, loading, error, setError, signInWithGoogle, signInWithKakao, getCurrentUserProfile };
 };
+


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-405
🔗https://coding-legend.atlassian.net/browse/MMEASY-414

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 관리자 페이지 조건부 랜더링
- [x] 나의 활동 페이지 내가 만든 퀴즈 오류 수정

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- 관리자 페이지에 접근 시 어드민 계정이 아닐경우 조건부 랜더링을 통해 랜더링을 막았습니다.
- 나의 활동 페이지에 내가 만든 퀴즈가 불러와지지 않는 오류 수정했습니다.

## 🚨 TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요. -->
- 기존에는 내가 만든 퀴즈가 잘 가져와졌으나, 사용하던 api 가 quiz 와 question 에 외래키 연결을 추가하면서
문제가 발생했었습니다. 해당 문제는 api 호출 시 가져오는 데이터가 question 의 외래키 부분이랑 혼란이 있을 수 있어서 
데이터를 가져오지 못했던 오류로 데이터를 명시적으로 적어주어 해결했습니다.
```
export const fetchUserQuizzes = async (email: string) => {
  try {
    const { data, error } = await supabase
      .from('quizzes')
      .select(`
        *,
        quiz_tries:quiz_tries!public_quiz_tries_quiz_id_fkey(id)
      `)
      .eq('creator_id', email);

    if (error) throw error;
    return data;
  } catch (error) {
    console.error('사용자 퀴즈 불러오기 실패', error);
  }
};
```