### PR TITLE
[feat] 타자연습 난이도 명 변경, 커뮤니티 공지 상단 고정

### DIFF
--- a/src/app/(community)/(components)/CommunityForm.tsx
+++ b/src/app/(community)/(components)/CommunityForm.tsx
@@ -1,9 +1,9 @@
-// CommunityForm.tsx
 'use client';
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import { formatToLocaleDateTimeString } from '@/utils/date';
+import { useMemo } from 'react';
 
 import type { CommunityFormProps } from '@/types/posts';
 
@@ -17,6 +17,18 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
   category
 }) => {
   const router = useRouter();
+
+  const sortedItems = useMemo(() => {
+    return [...currentItems].sort((a, b) => {
+      if (a.category === '공지' && b.category !== '공지') {
+        return -1; // a가 공지이면, b보다 앞에 오도록 정렬
+      }
+      if (a.category !== '공지' && b.category === '공지') {
+        return 1; // b가 공지이면, a보다 앞에 오도록 정렬
+      }
+      return 0; // 두 항목이 모두 공지이거나 공지가 아닐 경우 기본 순서 유지
+    });
+  }, [currentItems]);
 
   const navigateToDetailPost = (post: { id: string }): void => {
     if (category === null) {
@@ -45,8 +57,8 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
             </tr>
           </thead>
           <tbody>
-            {currentItems?.length > 0 ? (
-              currentItems.map((item, idx) => (
+          {sortedItems?.length > 0 ? (
+              sortedItems.map((item, idx) => (
                 <tr
                   className={`bg-white cursor-pointer border-y border-solid border-pointColor3 text-[calc(1vh+8px)] ${item['category'] === '공지' ? 'font-bold' : ''}`}
                   key={idx}

--- a/src/app/typing-game/page.tsx
+++ b/src/app/typing-game/page.tsx
@@ -10,13 +10,14 @@ import { isLoggedInAtom } from '@/store/store';
 import { useRouter } from 'next/navigation';
 
 import type { User } from '@/types/users';
+import type { DifficultySetting } from '@/types/difficultySetting';
 
-const difficultySettings: { [key: number]: { speed: number; interval: number } } = {
-  1: { speed: 20, interval: 5000 },
-  2: { speed: 30, interval: 4000 },
-  3: { speed: 40, interval: 3000 },
-  4: { speed: 50, interval: 2000 },
-  5: { speed: 60, interval: 1000 }
+const difficultySettings: { [key: number]: DifficultySetting } = {
+  1: { label: "왕초보", speed: 20, interval: 5000 },
+  2: { label: "초보", speed: 30, interval: 4000 },
+  3: { label: "중수", speed: 40, interval: 3000 },
+  4: { label: "고수", speed: 50, interval: 2000 },
+  5: { label: "지존", speed: 70, interval: 2000 }
 };
 
 const maxDifficulty = Object.keys(difficultySettings).length;
@@ -209,7 +210,7 @@ const TypingGamePage = () => {
           난이도
         </h2>
         <h3 className="w-[8%] h-full text-center text-pointColor2 border-solid border-r-2 border-pointColor1">
-          {difficulty}
+          {difficultySettings[difficulty].label}
         </h3>
         <h2 className="w-[8%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
           점수
@@ -263,7 +264,7 @@ const TypingGamePage = () => {
                     difficulty === index + 1 ? 'bg-pointColor1 text-white font-bold' : 'font-bold border border-solid'
                   } p-2 text-lg w-12 rounded-md`}
                 >
-                  {index + 1}
+                  {difficultySettings[index + 1].label}
                 </button>
               ))}
             </div>

--- a/src/types/difficultySetting.ts
+++ b/src/types/difficultySetting.ts
@@ -1,0 +1,5 @@
+export type DifficultySetting = {
+    label: string;
+    speed: number;
+    interval: number;
+}


### PR DESCRIPTION
## 📍 관련 이슈

🔗 https://coding-legend.atlassian.net/browse/MMEASY-421
🔗 https://coding-legend.atlassian.net/browse/MMEASY-422

## ✍️ Task TODOLIST

- [x] 타자연습 난이도 명 변경
- [x] 커뮤니티 공지글 상단 고정

## 🧑🏻‍💻 개발 내용

useMemo 와 sort 사용해 커뮤니티 공지글 상단으로 고정되게 구현했습니다.
```
  const sortedItems = useMemo(() => {
    return [...currentItems].sort((a, b) => {
      if (a.category === '공지' && b.category !== '공지') {
        return -1; // a가 공지이면, b보다 앞에 오도록 정렬
      }
      if (a.category !== '공지' && b.category === '공지') {
        return 1; // b가 공지이면, a보다 앞에 오도록 정렬
      }
      return 0; // 두 항목이 모두 공지이거나 공지가 아닐 경우 기본 순서 유지
    });
  }, [currentItems]);
```