### PR TITLE
[feat] 문제 페이지네이션 기능 구현 및 버튼 구성 & 결과 페이지에선 모든 문제 표시

### DIFF
--- a/src/app/(quiz)/quiz/[id]/Options.tsx
+++ b/src/app/(quiz)/quiz/[id]/Options.tsx
@@ -44,6 +44,7 @@ const Options = ({
               disabled={resultMode}
               name={questionId}
               onChange={() => onChange(questionId, is_answer, id)}
+              checked={usersAnswer?.option_id === id}
             />
             <p>{content}</p>
           </div>

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -250,7 +250,7 @@ const QuizTryPage = () => {
             )}
           </div>
         </article>
-        <main className="h-[76vh] pt-12 pb-20 flex flex-col justify-center place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 overflow-y-auto">
+        <main className="h-[76vh] pt-28 pb-14 flex flex-col justify-center place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 overflow-y-auto">
           {resultMode && (
             <h1 className="text-2xl">
               🎉 {questions.length}개 중에 {score}개 맞았습니다! 🎉
@@ -261,9 +261,10 @@ const QuizTryPage = () => {
               const { id, title, type, img_url, correct_answer } = question;
               const usersAnswer = usersAnswers.find((answer) => answer.id === id);
               const questionOrder = questions.indexOf(question);
+              const pageMode = !resultMode ? page === questionOrder : true;
 
               return (
-                page === questionOrder && (
+                pageMode && (
                   <section key={id} className="w-[570px] flex flex-col place-items-center gap-4">
                     <h3 className="self-start text-lg">{`${questions.indexOf(question) + 1}. ${title}`}</h3>
                     {img_url !== 'tempThumbnail.png' ? (
@@ -313,22 +314,24 @@ const QuizTryPage = () => {
               );
             })}
             <section className="w-[570px] flex flex-col justify-between gap-3">
-              <div className="flex justify-between gap-3">
-                <button
-                  disabled={page === 0}
-                  className={`w-full py-[9px] ${page === 0 ? 'bg-grayColor' : 'border border-solid border-pointColor1'} rounded-md`}
-                  onClick={handlePrevPage}
-                >
-                  이전 페이지
-                </button>
-                <button
-                  disabled={page === questions.length - 1}
-                  className={`w-full py-[9px] ${page === questions.length - 1 ? 'text-white bg-grayColor' : 'border border-solid border-pointColor1'} rounded-md`}
-                  onClick={handleNextPage}
-                >
-                  다음 페이지
-                </button>
-              </div>
+              {!resultMode && (
+                <div className="flex justify-between gap-3">
+                  <button
+                    disabled={page === 0}
+                    className={`w-full py-[9px] ${page === 0 ? 'bg-grayColor' : 'border border-solid border-pointColor1'} rounded-md`}
+                    onClick={handlePrevPage}
+                  >
+                    이전 페이지
+                  </button>
+                  <button
+                    disabled={page === questions.length - 1}
+                    className={`w-full py-[9px] ${page === questions.length - 1 ? 'text-white bg-grayColor' : 'border border-solid border-pointColor1'} rounded-md`}
+                    onClick={handleNextPage}
+                  >
+                    다음 페이지
+                  </button>
+                </div>
+              )}
               <button
                 className="w-full py-[9px] bg-pointColor1 text-white font-bold tracking-wider rounded-md"
                 onClick={handleResultMode}

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -250,7 +250,9 @@ const QuizTryPage = () => {
             )}
           </div>
         </article>
-        <main className="h-[76vh] pt-28 pb-14 flex flex-col justify-center place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 overflow-y-auto">
+        <main
+          className={`py-14 flex flex-col justify-center place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 ${resultMode ? '' : 'h-[76vh] overflow-y-auto'}`}
+        >
           {resultMode && (
             <h1 className="text-2xl">
               🎉 {questions.length}개 중에 {score}개 맞았습니다! 🎉
@@ -259,11 +261,11 @@ const QuizTryPage = () => {
           <article className="flex flex-col justify-between gap-8">
             {questions.map((question) => {
               const { id, title, type, img_url, correct_answer } = question;
-              const usersAnswer = usersAnswers.find((answer) => answer.id === id);
               const questionOrder = questions.indexOf(question);
               const pageMode = !resultMode ? page === questionOrder : true;
-              const userAnswer = usersAnswers.find((answer) => answer.id === id);
-              const answer = userAnswer ? (userAnswer.answer as string) : '';
+
+              const usersAnswer = usersAnswers.find((answer) => answer.id === id);
+              const answer = usersAnswer ? (usersAnswer.answer as string) : '';
 
               return (
                 pageMode && (

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useParams, useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
@@ -28,10 +28,10 @@ const QuizTryPage = () => {
   const [usersAnswers, setUsersAnswers] = useState<Answer[]>([]);
   const [score, setScore] = useState(0);
   const [page, setPage] = useState(0);
+  const [scrollPosition, setScrollPosition] = useState<number>(0);
 
   const { getCurrentUserProfile } = useAuth();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [scrollPosition, setScrollPosition] = useState<number>(0);
   const [currentUserEmail, setCurrentUserEmail] = useState<string | null>(null);
 
   const insertQuizMutation = useSubmitQuizTry();
@@ -250,9 +250,7 @@ const QuizTryPage = () => {
             )}
           </div>
         </article>
-        <main
-          className={`py-14 flex flex-col place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 ${resultMode ? '' : 'h-[76vh] overflow-y-scroll'}`}
-        >
+        <main className="py-14 flex flex-col justify-center items-center gap-10 bg-white border-solid border-l-2 border-pointColor1">
           {resultMode && (
             <h1 className="text-2xl">
               🎉 {questions.length}개 중에 {score}개 맞았습니다! 🎉

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -251,7 +251,7 @@ const QuizTryPage = () => {
           </div>
         </article>
         <main
-          className={`py-14 flex flex-col place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 ${resultMode ? '' : 'h-[76vh] overflow-y-auto'}`}
+          className={`py-14 flex flex-col place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 ${resultMode ? '' : 'h-[76vh] overflow-y-scroll'}`}
         >
           {resultMode && (
             <h1 className="text-2xl">
@@ -269,8 +269,13 @@ const QuizTryPage = () => {
 
               return (
                 pageMode && (
-                  <section key={id} className="w-[570px] flex flex-col place-items-center gap-4">
-                    <h3 className="self-start text-lg">{`${questions.indexOf(question) + 1}. ${title}`}</h3>
+                  <section key={id} className="w-[570px] flex flex-col items-center gap-4">
+                    <div className="w-full flex justify-between place-items-center">
+                      <h3 className="self-start text-lg">{`${questions.indexOf(question) + 1}. ${title}`}</h3>
+                      <h3>
+                        {questionOrder + 1}/{questions.length}
+                      </h3>
+                    </div>
                     {img_url !== 'tempThumbnail.png' ? (
                       <Image
                         src={`${storageUrl}/question-imgs/${img_url}`}

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -262,6 +262,8 @@ const QuizTryPage = () => {
               const usersAnswer = usersAnswers.find((answer) => answer.id === id);
               const questionOrder = questions.indexOf(question);
               const pageMode = !resultMode ? page === questionOrder : true;
+              const userAnswer = usersAnswers.find((answer) => answer.id === id);
+              const answer = userAnswer ? (userAnswer.answer as string) : '';
 
               return (
                 pageMode && (
@@ -296,6 +298,7 @@ const QuizTryPage = () => {
                           <>
                             <input
                               type="text"
+                              value={answer}
                               className="w-full pl-4 py-[9px] border-solid border border-pointColor1 rounded-md"
                               onChange={(e) => {
                                 handleMaxLength(e, 30);

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -27,11 +27,12 @@ const QuizTryPage = () => {
   const [resultMode, setResultMode] = useState(false);
   const [usersAnswers, setUsersAnswers] = useState<Answer[]>([]);
   const [score, setScore] = useState(0);
+  const [page, setPage] = useState(0);
 
-  const [scrollPosition, setScrollPosition] = useState<number>(0);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [currentUserEmail, setCurrentUserEmail] = useState<string | null>(null);
   const { getCurrentUserProfile } = useAuth();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [scrollPosition, setScrollPosition] = useState<number>(0);
+  const [currentUserEmail, setCurrentUserEmail] = useState<string | null>(null);
 
   const insertQuizMutation = useSubmitQuizTry();
   const updateQuizMutation = useUpdateQuizTry();
@@ -74,6 +75,16 @@ const QuizTryPage = () => {
     };
     fetchData();
   }, [isLoggedIn]);
+
+  const handlePrevPage = () => {
+    setPage(page - 1);
+    console.log(page);
+  };
+
+  const handleNextPage = () => {
+    setPage(page + 1);
+    console.log(page);
+  };
 
   const {
     data: quizData,
@@ -207,7 +218,7 @@ const QuizTryPage = () => {
   return (
     <>
       <Header level={level} title={title} />
-      <main className="grid grid-cols-[16%_84%] bg-bgColor1">
+      <div className="grid grid-cols-[16%_84%] bg-bgColor1">
         <article className="h-[76vh] text-pointColor1">
           <section>
             <Image
@@ -239,69 +250,93 @@ const QuizTryPage = () => {
             )}
           </div>
         </article>
-        <article className="pt-12 pb-20 flex flex-col justify-center place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1">
+        <main className="h-[76vh] pt-12 pb-20 flex flex-col justify-center place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 overflow-y-auto">
           {resultMode && (
             <h1 className="text-2xl">
               🎉 {questions.length}개 중에 {score}개 맞았습니다! 🎉
             </h1>
           )}
-          {questions.map((question) => {
-            const { id, title, type, img_url, correct_answer } = question;
-            const usersAnswer = usersAnswers.find((answer) => answer.id === id);
-            return (
-              <section key={id} className="w-[570px] flex flex-col place-items-center gap-4">
-                <h3 className="self-start text-lg">{`${questions.indexOf(question) + 1}. ${title}`}</h3>
-                {img_url !== 'tempThumbnail.png' ? (
-                  <Image
-                    src={`${storageUrl}/question-imgs/${img_url}`}
-                    alt="문제 이미지"
-                    width={570}
-                    height={200}
-                    className="h-[200px] mb-2 object-cover rounded-md"
-                  />
-                ) : (
-                  <></>
-                )}
-                {type === QuestionType.objective ? (
-                  <Options id={id} resultMode={resultMode} usersAnswer={usersAnswer} onChange={handleGetAnswer} />
-                ) : (
-                  <div className="w-full relative">
-                    {resultMode ? (
-                      <p
-                        className={`w-full pl-4 py-[9px] border-solid border ${
-                          usersAnswer?.answer === correct_answer
-                            ? ' border-pointColor1 bg-bgColor2'
-                            : 'border-pointColor2 bg-bgColor3'
-                        } rounded-md`}
-                      >
-                        {usersAnswer?.answer}
-                      </p>
+          <article className="flex flex-col justify-between gap-8">
+            {questions.map((question) => {
+              const { id, title, type, img_url, correct_answer } = question;
+              const usersAnswer = usersAnswers.find((answer) => answer.id === id);
+              const questionOrder = questions.indexOf(question);
+
+              return (
+                page === questionOrder && (
+                  <section key={id} className="w-[570px] flex flex-col place-items-center gap-4">
+                    <h3 className="self-start text-lg">{`${questions.indexOf(question) + 1}. ${title}`}</h3>
+                    {img_url !== 'tempThumbnail.png' ? (
+                      <Image
+                        src={`${storageUrl}/question-imgs/${img_url}`}
+                        alt="문제 이미지"
+                        width={570}
+                        height={200}
+                        className="h-[200px] mb-2 object-cover rounded-md"
+                      />
                     ) : (
-                      <>
-                        <input
-                          type="text"
-                          className="w-full pl-4 py-[9px] border-solid border border-pointColor1 rounded-md"
-                          onChange={(e) => {
-                            handleMaxLength(e, 30);
-                            handleGetAnswer(id, e.target.value);
-                          }}
-                        />
-                        <p className="absolute top-0 right-2 pt-3 pr-1 text-sm text-pointColor1">
-                          {handleGetLength(id)}/30
-                        </p>
-                      </>
+                      <></>
                     )}
-                  </div>
-                )}
-              </section>
-            );
-          })}
-          <button
-            className="w-[570px] pl-4 py-[9px] bg-pointColor1 text-white font-bold tracking-wider rounded-md"
-            onClick={handleResultMode}
-          >
-            {resultMode ? '다시 풀기' : '제출하기'}
-          </button>
+                    {type === QuestionType.objective ? (
+                      <Options id={id} resultMode={resultMode} usersAnswer={usersAnswer} onChange={handleGetAnswer} />
+                    ) : (
+                      <div className="w-full relative">
+                        {resultMode ? (
+                          <p
+                            className={`w-full pl-4 py-[9px] border-solid border ${
+                              usersAnswer?.answer === correct_answer
+                                ? ' border-pointColor1 bg-bgColor2'
+                                : 'border-pointColor2 bg-bgColor3'
+                            } rounded-md`}
+                          >
+                            {usersAnswer?.answer}
+                          </p>
+                        ) : (
+                          <>
+                            <input
+                              type="text"
+                              className="w-full pl-4 py-[9px] border-solid border border-pointColor1 rounded-md"
+                              onChange={(e) => {
+                                handleMaxLength(e, 30);
+                                handleGetAnswer(id, e.target.value);
+                              }}
+                            />
+                            <p className="absolute top-0 right-2 pt-3 pr-1 text-sm text-pointColor1">
+                              {handleGetLength(id)}/30
+                            </p>
+                          </>
+                        )}
+                      </div>
+                    )}
+                  </section>
+                )
+              );
+            })}
+            <section className="w-[570px] flex flex-col justify-between gap-3">
+              <div className="flex justify-between gap-3">
+                <button
+                  disabled={page === 0}
+                  className={`w-full py-[9px] ${page === 0 ? 'bg-grayColor' : 'border border-solid border-pointColor1'} rounded-md`}
+                  onClick={handlePrevPage}
+                >
+                  이전 페이지
+                </button>
+                <button
+                  disabled={page === questions.length - 1}
+                  className={`w-full py-[9px] ${page === questions.length - 1 ? 'text-white bg-grayColor' : 'border border-solid border-pointColor1'} rounded-md`}
+                  onClick={handleNextPage}
+                >
+                  다음 페이지
+                </button>
+              </div>
+              <button
+                className="w-full py-[9px] bg-pointColor1 text-white font-bold tracking-wider rounded-md"
+                onClick={handleResultMode}
+              >
+                {resultMode ? '다시 풀기' : '제출하기'}
+              </button>
+            </section>
+          </article>
           {resultMode && (
             <ReportButton
               targetId={id}
@@ -313,9 +348,9 @@ const QuizTryPage = () => {
               🚨 퀴즈에 오류가 있나요?
             </ReportButton>
           )}
-        </article>
+        </main>
         <PageUpBtn scrollPosition={scrollPosition} />
-      </main>
+      </div>
     </>
   );
 };

--- a/src/app/(quiz)/quiz/[id]/page.tsx
+++ b/src/app/(quiz)/quiz/[id]/page.tsx
@@ -251,7 +251,7 @@ const QuizTryPage = () => {
           </div>
         </article>
         <main
-          className={`py-14 flex flex-col justify-center place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 ${resultMode ? '' : 'h-[76vh] overflow-y-auto'}`}
+          className={`py-14 flex flex-col place-items-center gap-10 bg-white border-solid border-l-2 border-pointColor1 ${resultMode ? '' : 'h-[76vh] overflow-y-auto'}`}
         >
           {resultMode && (
             <h1 className="text-2xl">


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-431

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 문제 풀기 페이지 페이지네이션 기능 구현 및 이전/다음 버튼 구성
- [x] 결과 페이지에선 모든 문제 표시

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- page state 를 만들어서 그 페이지에 맞는 문제가 표시되도록 했습니다.
- 처음/마지막 페이지는 버튼이 클릭되지 않도록 했습니다.

quiz/[id]/page.tsx
```tsx
  const handlePrevPage = () => {
    setPage(page - 1);
  };
  const handleNextPage = () => {
    setPage(page + 1);
  };

<button disabled={page === 0} onClick={handlePrevPage}>
  이전 페이지
</button>
<button disabled={page === questions.length - 1} onClick={handleNextPage}>
  다음 페이지
</button>
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
<img width="1029" alt="스크린샷 2024-04-17 오후 3 10 16" src="https://github.com/mm-easy/mm-easy/assets/142870577/a38151f6-6288-4d69-b7dd-92ef790d1454">
<img width="762" alt="스크린샷 2024-04-17 오전 2 34 17" src="https://github.com/mm-easy/mm-easy/assets/142870577/4c5d2f85-864e-4e04-841a-c433400838a5">
<img width="762" alt="스크린샷 2024-04-17 오전 2 33 39" src="https://github.com/mm-easy/mm-easy/assets/142870577/34cba1c9-97a0-4ab4-ba17-45407ffeb738">

## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
- 긴 문제는 문제 영역 height 고정 시켜두고 스크롤이 생기게 하려고 했는데.. 담에 다시 도전해보겠습니다..