### PR TITLE
[style] tailwind screens lg(min: 1441px), md(min:861px) 설정 & 메인페이지 lg 레이아웃 수정

### DIFF
--- a/src/app/(main)/(components)/CommunitySection.tsx
+++ b/src/app/(main)/(components)/CommunitySection.tsx
@@ -3,19 +3,18 @@ import { getRecentPosts, getRecentNotice } from '@/api/posts';
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 
-  const CommunitySection = () => {
-
-    const { data: posts, isLoading: postsLoading } = useQuery({
-      queryKey: ['recentPosts'],
-      queryFn: getRecentPosts,
-      staleTime: 1000 * 60 * 5
+const CommunitySection = () => {
+  const { data: posts, isLoading: postsLoading } = useQuery({
+    queryKey: ['recentPosts'],
+    queryFn: getRecentPosts,
+    staleTime: 1000 * 60 * 5
   });
 
-    const { data: notices, isLoading: noticesLoading } = useQuery({
-      queryKey: ['recentNotice'],
-      queryFn: getRecentNotice,
-      staleTime: 1000 * 60 * 5
-    });
+  const { data: notices, isLoading: noticesLoading } = useQuery({
+    queryKey: ['recentNotice'],
+    queryFn: getRecentNotice,
+    staleTime: 1000 * 60 * 5
+  });
 
   if (postsLoading || noticesLoading) {
     return <div>로딩중..</div>;
@@ -23,54 +22,50 @@ import Link from 'next/link';
 
   return (
     <>
-      <div className="p-4 text-lg text-pointColor1 bg-bgColor1 font-bold border-y-2 border-solid border-pointColor1">
-        <div className="flex items-center justify-center">
-          <p className="w-5/6 ml-10">최근 올라온 글</p>
-        </div>
-      </div>
-      <section className="flex flex-col justify-center items-center">
-        <div className="w-5/6 flex">
-          <div className="w-1/2 p-8 border-r border-solid border-pointColor1">
-            <div className="flex justify-between">
-              <h2 className="mb-4 text-lg font-bold">공지</h2>
-              <Link href={`/community/list/전체`} className="font-semibold text-pointColor1">
-                더보기
-              </Link>
-            </div>
-            <div>
-              {notices?.map((notice, index) => (
-                <div
-                  key={notice.id}
-                  className={`py-4 ${index !== notices.length - 1 && 'border-b border-solid border-pointColor1'}`}
-                >
-                  <Link href={`/community/list/전체/${notice.id}`} className="flex flex-col gap-2">
-                    <h2 className="text-lg font-bold truncate">{notice.title}</h2>
-                    <time>작성일: {formatToLocaleDateTimeString(notice.created_at)}</time>
-                  </Link>
-                </div>
-              ))}
-            </div>
+      <p className="w-[1440px] px-6 py-4 text-lg font-bold text-pointColor1 bg-bgColor1 border-y-2 border-solid border-pointColor1">
+        최근 올라온 글
+      </p>
+      <section className="flex">
+        <div className="w-1/2 p-8 border-r border-solid border-pointColor1">
+          <div className="flex justify-between">
+            <h2 className="mb-4 text-lg font-bold">공지</h2>
+            <Link href={`/community/list/전체`} className="font-semibold text-pointColor1">
+              더보기
+            </Link>
           </div>
-          <div className="w-1/2 p-8">
-            <div className="flex justify-between">
-              <h2 className="mb-4 text-lg font-bold">유저가 쓴 글</h2>
-              <Link href={`/community/list/전체`} className="font-semibold text-pointColor1">
-                더보기
-              </Link>
-            </div>
-            <div>
-              {posts?.map((post, index) => (
-                <div
-                  key={post.id}
-                  className={`py-4 ${index !== posts.length - 1 && 'border-b border-solid border-pointColor1'}`}
-                >
-                  <Link href={`/community/list/전체/${post.id}`} className="flex flex-col gap-2">
-                    <h2 className="text-lg font-bold truncate">{post.title}</h2>
-                    <time>작성일: {formatToLocaleDateTimeString(post.created_at)}</time>
-                  </Link>
-                </div>
-              ))}
-            </div>
+          <div>
+            {notices?.map((notice, index) => (
+              <div
+                key={notice.id}
+                className={`py-4 ${index !== notices.length - 1 && 'border-b border-solid border-pointColor1'}`}
+              >
+                <Link href={`/community/list/전체/${notice.id}`} className="flex flex-col gap-2">
+                  <h2 className="text-lg font-bold truncate">{notice.title}</h2>
+                  <time>작성일: {formatToLocaleDateTimeString(notice.created_at)}</time>
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="w-1/2 p-8">
+          <div className="flex justify-between">
+            <h2 className="mb-4 text-lg font-bold">유저가 쓴 글</h2>
+            <Link href={`/community/list/전체`} className="font-semibold text-pointColor1">
+              더보기
+            </Link>
+          </div>
+          <div>
+            {posts?.map((post, index) => (
+              <div
+                key={post.id}
+                className={`py-4 ${index !== posts.length - 1 && 'border-b border-solid border-pointColor1'}`}
+              >
+                <Link href={`/community/list/전체/${post.id}`} className="flex flex-col gap-2">
+                  <h2 className="text-lg font-bold truncate">{post.title}</h2>
+                  <time>작성일: {formatToLocaleDateTimeString(post.created_at)}</time>
+                </Link>
+              </div>
+            ))}
           </div>
         </div>
       </section>

--- a/src/app/(main)/(components)/QuizSection.tsx
+++ b/src/app/(main)/(components)/QuizSection.tsx
@@ -20,39 +20,35 @@ const QuizSection = () => {
 
   return (
     <>
-      <div className="p-4 text-lg text-pointColor1 bg-bgColor1 font-bold border-b-2 border-solid border-pointColor1">
-        <div className="flex items-center justify-center">
-          <p className="w-5/6 ml-10">최근 올라온 퀴즈</p>
-          <Link href={`/quiz-list`} className="mr-10 font-semibold text-lg text-pointColor1">
-            더보기
-          </Link>
-        </div>
+      <div className="w-[1440px] px-6 py-4 flex justify-between items-center text-lg font-bold text-pointColor1 bg-bgColor1 border-b-2 border-solid border-pointColor1">
+        <p className="">최근 올라온 퀴즈</p>
+        <Link href={`/quiz-list`} className="font-semibold text-pointColor1">
+          더보기
+        </Link>
       </div>
-      <section className="flex flex-col justify-center items-center">
-        <div className="w-5/6 grid grid-cols-4 gap-5 p-4">
-          {quiz?.map((quiz) => (
-            <div
-              key={quiz.id}
-              className="flex flex-col border my-5 border-solid border-gray-200 rounded-t-3xl rounded-b-md p-4 transition duration-300 ease-in-out transform hover:border-blue-500"
-            >
-              <p className="font-bold text-lg mt-4 mb-3 truncate">{quiz.title}</p>
-              <div className="flex flex-col gap-3">
-                <Image
-                  src={`${storageUrl}/quiz-thumbnails/${quiz.thumbnail_img_url}`}
-                  alt="퀴즈 썸네일"
-                  width={250}
-                  height={250}
-                  quality={100}
-                  className="w-full h-[250px] object-cover border-solid border border-gray-200 rounded-md"
-                />
-                <QuestionEx id={quiz.id} />
-                <Link href={`/quiz/${quiz.id}`}>
-                  <div className="text-white bg-pointColor1 rounded-md p-2 text-center">퀴즈 풀기</div>
-                </Link>
-              </div>
+      <section className="px-6 py-4 grid grid-cols-4 gap-5">
+        {quiz?.map((quiz) => (
+          <div
+            key={quiz.id}
+            className="p-4 flex flex-col my-5 border border-solid border-grayColor1 rounded-t-3xl rounded-b-md transition duration-300 ease-in-out transform hover:border-blue-500"
+          >
+            <p className="font-bold text-lg mt-4 mb-3 truncate">{quiz.title}</p>
+            <div className="flex flex-col gap-3">
+              <Image
+                src={`${storageUrl}/quiz-thumbnails/${quiz.thumbnail_img_url}`}
+                alt="퀴즈 썸네일"
+                width={250}
+                height={250}
+                quality={100}
+                className="w-full h-[250px] object-cover border border-solid border-grayColor1 rounded-md"
+              />
+              <QuestionEx id={quiz.id} />
+              <Link href={`/quiz/${quiz.id}`}>
+                <div className="p-2 text-center text-white bg-pointColor1 rounded-md">퀴즈 풀기</div>
+              </Link>
             </div>
-          ))}
-        </div>
+          </div>
+        ))}
       </section>
     </>
   );

--- a/src/app/(main)/(components)/RankingSection.tsx
+++ b/src/app/(main)/(components)/RankingSection.tsx
@@ -27,103 +27,99 @@ const RankingSection = () => {
 
   return (
     <>
-      <div className="p-4 text-lg text-pointColor1 bg-bgColor1 font-bold border-y-2 border-solid border-pointColor1">
-        <div className="flex items-center justify-center">
-          <p className="w-5/6 ml-10">명예의 전당</p>
+      <p className="w-[1440px] px-6 py-4 text-lg font-bold text-pointColor1 bg-bgColor1 border-y-2 border-solid border-pointColor1">
+        명예의 전당
+      </p>
+      <section className="flex">
+        <div className="w-1/3 p-8 border-r border-solid border-pointColor1">
+          <div className="flex">
+            <h2 className="mb-4 text-lg font-bold">이번주 퀴즈 만들기 장인</h2>
+          </div>
+          {quizRank &&
+            quizRank.map((item, index) => (
+              <div
+                key={index}
+                className={`mt-4 pb-4 flex items-center ${
+                  index !== quizRank.length - 1 && 'border-b border-solid border-pointColor1'
+                }`}
+              >
+                {item.avatar_img_url && (
+                  <div className="mr-4 w-[65px] h-[65px] rounded-full overflow-hidden border-2 border-solid border-pointColor1 flex-shrink-0">
+                    <Image
+                      src={`${profileStorageUrl}/${item.avatar_img_url}`}
+                      alt="프로필 이미지"
+                      width={60}
+                      height={60}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                )}
+                <div className="flex flex-col">
+                  <h3 className="text-xl font-medium mb-1">{item.nickname}</h3>
+                  <h2 className="text-pointColor1">만든 퀴즈수: {item.quiz_count}</h2>
+                </div>
+              </div>
+            ))}
         </div>
-      </div>
-      <section className="flex flex-col justify-center items-center">
-        <div className="w-5/6 flex">
-          <div className="w-1/3 p-8 border-r border-solid border-pointColor1">
-            <div className="flex">
-              <h2 className="mb-4 text-lg font-bold">이번주 퀴즈 만들기 장인</h2>
-            </div>
-            {quizRank &&
-              quizRank.map((item, index) => (
-                <div
-                  key={index}
-                  className={`mt-4 pb-4 flex items-center ${
-                    index !== quizRank.length - 1 && 'border-b border-solid border-pointColor1'
-                  }`}
-                >
-                  {item.avatar_img_url && (
-                    <div className="mr-4 w-[65px] h-[65px] rounded-full overflow-hidden border-2 border-solid border-pointColor1 flex-shrink-0">
-                      <Image
-                        src={`${profileStorageUrl}/${item.avatar_img_url}`}
-                        alt="프로필 이미지"
-                        width={60}
-                        height={60}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                  )}
-                  <div className="flex flex-col">
-                    <h3 className="text-xl font-medium mb-1">{item.nickname}</h3>
-                    <h2 className="text-pointColor1">만든 퀴즈수: {item.quiz_count}</h2>
-                  </div>
-                </div>
-              ))}
+        <div className="w-1/3 p-8 border-r border-solid border-pointColor1">
+          <div className="flex">
+            <h2 className="mb-4 text-lg font-bold">이번주 퀴즈 마스터</h2>
           </div>
-          <div className="w-1/3 p-8 border-r border-solid border-pointColor1">
-            <div className="flex">
-              <h2 className="mb-4 text-lg font-bold">이번주 퀴즈 마스터</h2>
-            </div>
-            {quizScoreRank &&
-              quizScoreRank.map((item, index) => (
-                <div
-                  key={index}
-                  className={`mt-4 pb-4 flex items-center ${
-                    index !== quizScoreRank.length - 1 && 'border-b border-solid border-pointColor1'
-                  }`}
-                >
-                  {item.avatar_img_url && (
-                    <div className="mr-4 w-[65px] h-[65px] rounded-full overflow-hidden border-2 border-solid border-pointColor1 flex-shrink-0">
-                      <Image
-                        src={`${profileStorageUrl}/${item.avatar_img_url}`}
-                        alt="프로필 이미지"
-                        width={60}
-                        height={60}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                  )}
-                  <div className="flex flex-col">
-                    <h3 className="text-xl font-medium mb-1">{item.nickname}</h3>
-                    <h2 className="text-pointColor1">점수: {item.score}</h2>
+          {quizScoreRank &&
+            quizScoreRank.map((item, index) => (
+              <div
+                key={index}
+                className={`mt-4 pb-4 flex items-center ${
+                  index !== quizScoreRank.length - 1 && 'border-b border-solid border-pointColor1'
+                }`}
+              >
+                {item.avatar_img_url && (
+                  <div className="mr-4 w-[65px] h-[65px] rounded-full overflow-hidden border-2 border-solid border-pointColor1 flex-shrink-0">
+                    <Image
+                      src={`${profileStorageUrl}/${item.avatar_img_url}`}
+                      alt="프로필 이미지"
+                      width={60}
+                      height={60}
+                      className="w-full h-full object-cover"
+                    />
                   </div>
+                )}
+                <div className="flex flex-col">
+                  <h3 className="text-xl font-medium mb-1">{item.nickname}</h3>
+                  <h2 className="text-pointColor1">점수: {item.score}</h2>
                 </div>
-              ))}
+              </div>
+            ))}
+        </div>
+        <div className="w-1/3 p-8 border-solid border-pointColor1">
+          <div className="flex">
+            <h2 className="mb-4 text-lg font-bold">이번주 키보드 워리어</h2>
           </div>
-          <div className="w-1/3 p-8 border-solid border-pointColor1">
-            <div className="flex">
-              <h2 className="mb-4 text-lg font-bold">이번주 키보드 워리어</h2>
-            </div>
-            {gameScores &&
-              gameScores.map((score, index) => (
-                <div
-                  key={index}
-                  className={`mt-4 pb-4 flex items-center ${
-                    index !== gameScores.length - 1 && 'border-b border-solid border-pointColor1'
-                  }`}
-                >
-                  {score.avatar_img_url && (
-                    <div className="mr-4 w-[65px] h-[65px] rounded-full overflow-hidden border-2 border-solid border-pointColor1 flex-shrink-0">
-                      <Image
-                        src={`${profileStorageUrl}/${score.avatar_img_url}`}
-                        alt="프로필 이미지"
-                        width={60}
-                        height={60}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                  )}
-                  <div className="flex flex-col">
-                    <h3 className="text-xl font-medium mb-1">{score.nickname}</h3>
-                    <h2 className="text-pointColor1">점수: {score.score}</h2>
+          {gameScores &&
+            gameScores.map((score, index) => (
+              <div
+                key={index}
+                className={`mt-4 pb-4 flex items-center ${
+                  index !== gameScores.length - 1 && 'border-b border-solid border-pointColor1'
+                }`}
+              >
+                {score.avatar_img_url && (
+                  <div className="mr-4 w-[65px] h-[65px] rounded-full overflow-hidden border-2 border-solid border-pointColor1 flex-shrink-0">
+                    <Image
+                      src={`${profileStorageUrl}/${score.avatar_img_url}`}
+                      alt="프로필 이미지"
+                      width={60}
+                      height={60}
+                      className="w-full h-full object-cover"
+                    />
                   </div>
+                )}
+                <div className="flex flex-col">
+                  <h3 className="text-xl font-medium mb-1">{score.nickname}</h3>
+                  <h2 className="text-pointColor1">점수: {score.score}</h2>
                 </div>
-              ))}
-          </div>
+              </div>
+            ))}
         </div>
       </section>
     </>

--- a/src/app/community/list/[category]/CommunityForm.tsx
+++ b/src/app/community/list/[category]/CommunityForm.tsx
@@ -64,7 +64,7 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
                   className={`cursor-pointer text-[calc(1vh+8px)] ${
                     item['category'] === '공지'
                       ? 'font-bold bg-bgColor2 border-y border-solid border-pointColor1'
-                      : 'bg-white border-grayColor border-y border-solid '
+                      : 'bg-white border-grayColor2 border-y border-solid '
                   }`}
                   key={idx}
                   onClick={() => navigateToDetailPost(item)}

--- a/src/app/community/list/[category]/CommunityForm.tsx
+++ b/src/app/community/list/[category]/CommunityForm.tsx
@@ -62,7 +62,9 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
               sortedItems.map((item, idx) => (
                 <tr
                   className={`cursor-pointer text-[calc(1vh+8px)] ${
-                    item['category'] === '공지' ? 'font-bold bg-bgColor2 border-y border-solid border-pointColor1' : 'bg-white border-pointColor3 border-y border-solid '
+                    item['category'] === '공지'
+                      ? 'font-bold bg-bgColor2 border-y border-solid border-pointColor1'
+                      : 'bg-white border-grayColor border-y border-solid '
                   }`}
                   key={idx}
                   onClick={() => navigateToDetailPost(item)}

--- a/src/app/community/list/[category]/[id]/Comment.tsx
+++ b/src/app/community/list/[category]/[id]/Comment.tsx
@@ -68,7 +68,7 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
       <div>
         {postCommentList?.map((prev) => {
           return (
-            <div className="pt-8 flex border-solid border-b border-pointColor3" key={prev.id}>
+            <div className="pt-8 flex border-solid border-b border-grayColor" key={prev.id}>
               <div className="w-[50px] h-[50px] m-5 ml-0 flex justify-center rounded-full overflow-hidden">
                 <Image
                   src={`${profileStorageUrl}/${prev.profiles?.avatar_img_url || '프로필이미지'}`}
@@ -84,7 +84,7 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
                 {btnChange && nowCommentId === prev.id ? (
                   <div>
                     <textarea
-                      className="resize-none focus:outline-none border-solid border border-pointColor3 "
+                      className="resize-none focus:outline-none border-solid border border-grayColor "
                       value={contentChange}
                       onChange={(e) => setContentChange(e.target.value)}
                       placeholder="Reply to comment…"
@@ -141,7 +141,7 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
       </div>
       <div className="mt-8">
         <form onSubmit={handleSubmitBtn}>
-          <div className="border-solid border border-pointColor3">
+          <div className="border-solid border border-grayColor">
             <div className="p-4">
               <span className="text-blackColor font-bold">{profile?.nickname}</span>
               <div>

--- a/src/app/community/list/[category]/[id]/Comment.tsx
+++ b/src/app/community/list/[category]/[id]/Comment.tsx
@@ -68,7 +68,7 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
       <div>
         {postCommentList?.map((prev) => {
           return (
-            <div className="pt-8 flex border-solid border-b border-grayColor" key={prev.id}>
+            <div className="pt-8 flex border-solid border-b border-grayColor2" key={prev.id}>
               <div className="w-[50px] h-[50px] m-5 ml-0 flex justify-center rounded-full overflow-hidden">
                 <Image
                   src={`${profileStorageUrl}/${prev.profiles?.avatar_img_url || '프로필이미지'}`}
@@ -84,7 +84,7 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
                 {btnChange && nowCommentId === prev.id ? (
                   <div>
                     <textarea
-                      className="resize-none focus:outline-none border-solid border border-grayColor "
+                      className="resize-none focus:outline-none border-solid border border-grayColor2"
                       value={contentChange}
                       onChange={(e) => setContentChange(e.target.value)}
                       placeholder="Reply to comment…"
@@ -141,7 +141,7 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
       </div>
       <div className="mt-8">
         <form onSubmit={handleSubmitBtn}>
-          <div className="border-solid border border-grayColor">
+          <div className="border-solid border border-grayColor2">
             <div className="p-4">
               <span className="text-blackColor font-bold">{profile?.nickname}</span>
               <div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,15 +24,17 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={gothic_a1.className}>
-        <Provider>
-          <QueryProvider>
-            <Header />
-            <ToastContainer />
-            {children}
-            <Footer />
-          </QueryProvider>
-        </Provider>
+      <body className={`bg-bgColor1 ${gothic_a1.className}`}>
+        <main className="mx-auto lg:w-[1440px] lg:bg-white lg:border-x-2 lg:border-solid lg:border-pointColor1 md:w-full">
+          <Provider>
+            <QueryProvider>
+              <Header />
+              <ToastContainer />
+              {children}
+              <Footer />
+            </QueryProvider>
+          </Provider>
+        </main>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`bg-bgColor1 ${gothic_a1.className}`}>
-        <main className="mx-auto lg:w-[1440px] lg:bg-white lg:border-x-2 lg:border-solid lg:border-pointColor1 md:w-full">
+        <main className="mx-auto bg-white lg:w-[1444px] lg:border-x-2 lg:border-solid lg:border-pointColor1 md:w-full">
           <Provider>
             <QueryProvider>
               <Header />

--- a/src/app/my-activity/MyActivity.tsx
+++ b/src/app/my-activity/MyActivity.tsx
@@ -197,7 +197,7 @@ const MyActivity = () => {
             <tbody>
               {currentSolvedQuizzes && currentSolvedQuizzes.length > 0 ? (
                 currentSolvedQuizzes.map((quiz, index) => (
-                  <tr className="bg-white border-b border-solid border-grayColor" key={index}>
+                  <tr className="bg-white border-b border-solid border-grayColor2" key={index}>
                     <td className="py-4 w-24">{quiz.quizzes.title}</td>
                     <td>{quiz.score}</td>
                     <td>{formatToLocaleDateTimeString(quiz.created_at)}</td>
@@ -236,7 +236,7 @@ const MyActivity = () => {
             <tbody>
               {currentQuizzes && currentQuizzes.length > 0 ? (
                 currentQuizzes.map((quiz, index) => (
-                  <tr className="bg-white border-b border-solid border-grayColor" key={index}>
+                  <tr className="bg-white border-b border-solid border-grayColor2" key={index}>
                     <td className="py-4 w-24">
                       <a href={`/quiz/${quiz.id}`}>{quiz.title}</a>
                     </td>
@@ -277,7 +277,7 @@ const MyActivity = () => {
             <tbody>
               {currentPosts && currentPosts.length > 0 ? (
                 currentPosts.map((post, index) => (
-                  <tr className="bg-white border-b border-solid border-grayColor" key={index}>
+                  <tr className="bg-white border-b border-solid border-grayColor2" key={index}>
                     <td className="truncate max-w-xs pr-12 py-4 w-24">
                       <a href={`/community/list/${post.category}/${post.id}`}>{post.title}</a>
                     </td>
@@ -312,7 +312,7 @@ const MyActivity = () => {
             <tbody>
               {currentComments && currentComments.length > 0 ? (
                 currentComments.map((comment, index) => (
-                  <tr className="bg-white border-b border-solid border-grayColor" key={index}>
+                  <tr className="bg-white border-b border-solid border-grayColor2" key={index}>
                     <td className="truncate max-w-xs py-4 w-24">{comment.content}</td>
                     <td>{formatToLocaleDateTimeString(comment.created_at)}</td>
                     <td className="text-right">

--- a/src/app/my-activity/MyActivity.tsx
+++ b/src/app/my-activity/MyActivity.tsx
@@ -127,7 +127,7 @@ const MyActivity = () => {
     enabled: isLoggedIn // 로그인 상태일 때만 쿼리 활성화
   });
 
-  // 
+  //
   const navigateToQuiz = (puizId: string) => {
     router.push(`/quiz/${puizId}`);
   };
@@ -197,7 +197,7 @@ const MyActivity = () => {
             <tbody>
               {currentSolvedQuizzes && currentSolvedQuizzes.length > 0 ? (
                 currentSolvedQuizzes.map((quiz, index) => (
-                  <tr className="bg-white border-b border-solid border-pointColor3" key={index}>
+                  <tr className="bg-white border-b border-solid border-grayColor" key={index}>
                     <td className="py-4 w-24">{quiz.quizzes.title}</td>
                     <td>{quiz.score}</td>
                     <td>{formatToLocaleDateTimeString(quiz.created_at)}</td>
@@ -236,7 +236,7 @@ const MyActivity = () => {
             <tbody>
               {currentQuizzes && currentQuizzes.length > 0 ? (
                 currentQuizzes.map((quiz, index) => (
-                  <tr className="bg-white border-b border-solid border-pointColor3" key={index}>
+                  <tr className="bg-white border-b border-solid border-grayColor" key={index}>
                     <td className="py-4 w-24">
                       <a href={`/quiz/${quiz.id}`}>{quiz.title}</a>
                     </td>
@@ -277,7 +277,7 @@ const MyActivity = () => {
             <tbody>
               {currentPosts && currentPosts.length > 0 ? (
                 currentPosts.map((post, index) => (
-                  <tr className="bg-white border-b border-solid border-pointColor3" key={index}>
+                  <tr className="bg-white border-b border-solid border-grayColor" key={index}>
                     <td className="truncate max-w-xs pr-12 py-4 w-24">
                       <a href={`/community/list/${post.category}/${post.id}`}>{post.title}</a>
                     </td>
@@ -312,7 +312,7 @@ const MyActivity = () => {
             <tbody>
               {currentComments && currentComments.length > 0 ? (
                 currentComments.map((comment, index) => (
-                  <tr className="bg-white border-b border-solid border-pointColor3" key={index}>
+                  <tr className="bg-white border-b border-solid border-grayColor" key={index}>
                     <td className="truncate max-w-xs py-4 w-24">{comment.content}</td>
                     <td>{formatToLocaleDateTimeString(comment.created_at)}</td>
                     <td className="text-right">
@@ -336,10 +336,10 @@ const MyActivity = () => {
           activeTab === 'solvedQuizzes'
             ? userSolvedQuiz.length
             : activeTab === 'quizzes'
-            ? userQuiz.length
-            : activeTab === 'posts'
-            ? userPost.length
-            : userComment.length
+              ? userQuiz.length
+              : activeTab === 'posts'
+                ? userPost.length
+                : userComment.length
         }
         itemsPerPage={itemsPerPage}
         currentPage={currentPage}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,7 @@ const Home = () => {
   }, [scrollPosition]);
 
   return (
-    <div className="min-h-screen">
+    <div>
       <Banner />
       <QuizSection />
       <RankingSection />

--- a/src/app/quiz/[id]/page.tsx
+++ b/src/app/quiz/[id]/page.tsx
@@ -344,7 +344,7 @@ const QuizTryPage = () => {
                   <button
                     disabled={page === 0}
                     className={`w-full py-[9px] ${
-                      page === 0 ? 'text-white bg-grayColor' : 'border border-solid border-pointColor1'
+                      page === 0 ? 'text-white bg-grayColor2' : 'border border-solid border-pointColor1'
                     } rounded-md`}
                     onClick={handlePrevPage}
                   >
@@ -354,7 +354,7 @@ const QuizTryPage = () => {
                     disabled={page === questions.length - 1}
                     className={`w-full py-[9px] ${
                       page === questions.length - 1
-                        ? 'text-white bg-grayColor'
+                        ? 'text-white bg-grayColor2'
                         : 'border border-solid border-pointColor1'
                     } rounded-md`}
                     onClick={handleNextPage}

--- a/src/app/quiz/form/PlusQuestionBtn.tsx
+++ b/src/app/quiz/form/PlusQuestionBtn.tsx
@@ -8,7 +8,7 @@ const PlusQuestionBtn: React.FC<PlusQuestionBtnProps> = ({ disabled, onClick }) 
     <div className="flex justify-center">
       <button
         type="button"
-        className={`w-[570px] mb-9 p-2 text-white ${disabled ? 'bg-grayColor cursor-default' : 'bg-pointColor1'} rounded-md`}
+        className={`w-[570px] mb-9 p-2 text-white ${disabled ? 'bg-grayColor2 cursor-default' : 'bg-pointColor1'} rounded-md`}
         onClick={onClick}
       >
         문제 추가하기

--- a/src/app/quiz/form/QuestionForm.tsx
+++ b/src/app/quiz/form/QuestionForm.tsx
@@ -242,7 +242,7 @@ const QuestionForm = ({
                   <button
                     type="button"
                     className={`w-full text-3xl border-solid border ${
-                      options.length === 5 ? 'text-grayColor border-grayColor cursor-default' : 'border-pointColor1'
+                      options.length === 5 ? 'text-grayColor2 border-grayColor2 cursor-default' : 'border-pointColor1'
                     } rounded-md`}
                     onClick={() => handleAddOption(id, options)}
                   >

--- a/src/app/quiz/form/QuizForm.tsx
+++ b/src/app/quiz/form/QuizForm.tsx
@@ -341,7 +341,7 @@ const QuizForm = () => {
           <div className="flex gap-10">
             <div
               onClick={handleClickImg}
-              className="relative bg-gray-200 w-36 h-36 border-solid border border-pointColor1 rounded-md overflow-hidden"
+              className="relative bg-grayColor1 w-36 h-36 border-solid border border-pointColor1 rounded-md overflow-hidden"
             >
               <Image
                 src={selectedImg}

--- a/src/app/quiz/list/QuizList.tsx
+++ b/src/app/quiz/list/QuizList.tsx
@@ -47,7 +47,7 @@ const QuizList = ({ quizLevelSelected, currentUser }: { quizLevelSelected: Quiz[
         {quizLevelSelected.map((item) => (
           <div
             key={item.id}
-            className="flex flex-col border my-3 border-solid border-gray-200 rounded-t-3xl rounded-b-md p-4 cursor-pointer transition duration-300 ease-in-out transform hover:border-blue-500"
+            className="flex flex-col border my-3 border-solid border-grayColor1 rounded-t-3xl rounded-b-md p-4 cursor-pointer transition duration-300 ease-in-out transform hover:border-blue-500"
             onClick={() => {
               handleShowModal(item.id);
             }}
@@ -60,7 +60,7 @@ const QuizList = ({ quizLevelSelected, currentUser }: { quizLevelSelected: Quiz[
                 width={250}
                 height={250}
                 quality={100}
-                className="w-full h-[250px] object-cover border-solid border border-gray-200 rounded-md"
+                className="w-full h-[250px] object-cover border-solid border border-grayColor1 rounded-md"
               />
               <p className="mb-4 line-clamp-2">{item.info}</p>
             </div>

--- a/src/app/typing-game/page.tsx
+++ b/src/app/typing-game/page.tsx
@@ -13,11 +13,11 @@ import type { User } from '@/types/users';
 import type { DifficultySetting } from '@/types/difficultySetting';
 
 const difficultySettings: { [key: number]: DifficultySetting } = {
-  1: { label: "초보", speed: 20, interval: 5000 },
-  2: { label: "하수", speed: 30, interval: 4000 },
-  3: { label: "중수", speed: 40, interval: 3000 },
-  4: { label: "고수", speed: 50, interval: 2000 },
-  5: { label: "지존", speed: 70, interval: 2000 }
+  1: { label: '초보', speed: 20, interval: 5000 },
+  2: { label: '하수', speed: 30, interval: 4000 },
+  3: { label: '중수', speed: 40, interval: 3000 },
+  4: { label: '고수', speed: 50, interval: 2000 },
+  5: { label: '지존', speed: 70, interval: 2000 }
 };
 
 const maxDifficulty = Object.keys(difficultySettings).length;
@@ -104,11 +104,11 @@ const TypingGamePage = () => {
       if (user) {
         addGameScore(score);
       }
-       setGameStarted(false);
-       setScore(0); 
-       setLives(maxLives); 
-       setWords([]); 
-       setCorrectWordsCount(0);
+      setGameStarted(false);
+      setScore(0);
+      setLives(maxLives);
+      setWords([]);
+      setCorrectWordsCount(0);
     }
   }, [lives, score, user]);
 
@@ -248,7 +248,7 @@ const TypingGamePage = () => {
             ))}
             <form
               onSubmit={handleSubmit}
-              className="h-[10vh] flex gap-3 justify-center absolute bottom-0 left-0 right-0 p-4 bg-pointColor4"
+              className="h-[10vh] flex gap-3 justify-center absolute bottom-0 left-0 right-0 p-4 bg-pointColor3"
             >
               <input
                 type="text"
@@ -271,17 +271,16 @@ const TypingGamePage = () => {
                   key={index + 1}
                   onClick={() => handleDifficultyChange(index + 1)}
                   className={`text-pointColor1 mx-3 mb-6 ${
-                    difficulty === index + 1 ? 'bg-pointColor1 text-white font-bold' : 'font-bold border border-solid border-pointColor1'
+                    difficulty === index + 1
+                      ? 'bg-pointColor1 text-white font-bold'
+                      : 'font-bold border border-solid border-pointColor1'
                   } p-2 text-lg w-12 rounded-md`}
                 >
                   {difficultySettings[index + 1].label}
                 </button>
               ))}
             </div>
-            <button 
-              onClick={startGame} 
-              className="w-[25%] bg-pointColor1 text-white text-lg font-bold p-4 rounded"
-            >
+            <button onClick={startGame} className="w-[25%] bg-pointColor1 text-white text-lg font-bold p-4 rounded">
               시작하기
             </button>
           </div>

--- a/src/components/common/PageUpBtn.tsx
+++ b/src/components/common/PageUpBtn.tsx
@@ -31,7 +31,9 @@ const PageUpBtn = ({ scrollPosition }: PageUpBtnProps) => {
   }, [scrollPosition]);
 
   return (
-    <div className="fixed bottom-[110px] right-[40px] cursor-pointer origin-center rotate-[270deg] rounded-full bg-pointColor1">
+    <div
+      className={`fixed bottom-[110px] right-[20px] bg-pointColor1 rounded-full origin-center rotate-[270deg] cursor-pointer`}
+    >
       {isVisible && <ArrowCircle width={40} height={40} onClick={handlePageUp} fill="#fff" />}
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,13 +16,16 @@ const config: Config = {
         bgColor3: '#FFF0EF',
         pointColor1: '#2B84ED',
         pointColor2: '#FF8878',
-        pointColor3: '#D9D9D9',
-        pointColor4: '#8dbdf6',
+        pointColor3: '#8dbdf6',
         blackColor: '#2E2E2E',
         grayColor: '#D9D9D9'
-      },
+      }
     },
-    backgroundSize: { md: '80%', cover: 'cover' }
+    backgroundSize: { md: '80%', cover: 'cover' },
+    screens: {
+      lg: '1440px',
+      md: '860px'
+    }
   },
   darkMode: 'class',
   plugins: [nextui()]

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,13 +18,14 @@ const config: Config = {
         pointColor2: '#FF8878',
         pointColor3: '#8dbdf6',
         blackColor: '#2E2E2E',
-        grayColor: '#D9D9D9'
+        grayColor1: '#E5E7EB',
+        grayColor2: '#D9D9D9'
       }
     },
     backgroundSize: { md: '80%', cover: 'cover' },
     screens: {
-      lg: '1440px',
-      md: '860px'
+      lg: '1441px',
+      md: '861px'
     }
   },
   darkMode: 'class',


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-442
🔗 https://coding-legend.atlassian.net/browse/MMEASY-443

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] className 에 쓸 screens 설정, lg - 1441 이상 웹, md - 861 ~ 1440 웹
- [x] tailwind 컬러명 변경 (조금 바뀐 것들이 있습니다! 아래 사진 넣어둘게요!)
- [x] 메인페이지 레이아웃 1440 맞춰 수정

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- body 에 베이지 컬러를 깔고 가운데 저희 컨텐츠 넣는 쪽을 화이트로 깔았습니다!
메인만 변경을 해놔서 아직 다른 메뉴는 베이지가 배경인 곳이 있을 거에요.

app/layout.tsx
```tsx
<body className={`bg-bgColor1 ${gothic_a1.className}`}>
  <main className="mx-auto bg-white lg:w-[1444px] lg:border-x-2 lg:border-solid lg:border-pointColor1 md:w-full">
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
![스크린샷 2024-04-17 오후 10 39 03](https://github.com/mm-easy/mm-easy/assets/142870577/dc9638d9-fc63-4e23-a178-af27ebaf5f07)

- 기존에 넣어놨던 진한 그레이컬러를 grayColor2로 두고, gray-200 으로 사용하고 있던 연한 그레이를 grayColor1으로 넣어놨습니다!
사용하시던 곳은 수정해놨습니다!
![스크린샷 2024-04-17 오후 10 06 35](https://github.com/mm-easy/mm-easy/assets/142870577/266ec736-b5ca-4509-8023-725d2c9bce79)

- 페이지업버튼을 어찌해야할지 고민입니다..
![스크린샷 2024-04-17 오후 10 39 19](https://github.com/mm-easy/mm-easy/assets/142870577/9175b6c6-4c0b-410e-a833-ad7bbdbacc27)
