### PR TITLE
[style] 프로필/점수 영역 세로 중앙 정렬

### DIFF
--- a/src/app/profile/MyLevelAndScore.tsx
+++ b/src/app/profile/MyLevelAndScore.tsx
@@ -67,8 +67,8 @@ const MyLevelAndScore = ({ data }: { data: User }) => {
     myTotalScore < 5000 ? 1 : myTotalScore < 15000 ? 2 : myTotalScore < 35000 ? 3 : myTotalScore < 70000 ? 4 : 5;
 
   return (
-    <main className="w-full h-full flex flex-col items-center bg-bgColor2 border-solid border-t border-pointColor1">
-      <div className="mt-10 text-xl font-semibold">
+    <main className="w-full h-full flex flex-col justify-center items-center bg-bgColor2 border-solid border-t border-pointColor1">
+      <div className="text-xl font-semibold">
         전체 올라온 퀴즈 <span className="text-pointColor1">{quizData?.length}</span>개 중{' '}
         <span className="text-pointColor1">{myQuizScores?.length}</span>개의 퀴즈를 풀었어요!
       </div>

--- a/src/app/profile/MyProfile.tsx
+++ b/src/app/profile/MyProfile.tsx
@@ -72,34 +72,36 @@ const MyProfile = ({ data }: { data: User }) => {
 
   return (
     <main className="w-full h-full flex flex-col items-center">
-      <h3 className="mt-10 text-center text-pointColor1 text-xl font-semibold">프로필</h3>
-      <article className="flex gap-20 mt-5">
-        <section className="w-[230px] h-[230px]">
-          <Image
-            src={`${profileStorageUrl}/${data.avatar_img_url}`}
-            alt="사용자 프로필"
-            width={250}
-            height={250}
-            className="bg-bgColor2 w-full h-full object-cover border-solid border border-pointColor1 rounded-full"
-          />
-        </section>
-        <section className="flex flex-col justify-around">
-          <div className="flex flex-col gap-5">
-            <div className="flex flex-col gap-1">
-              <p className="text-pointColor1 font-semibold">닉네임</p>
-              <p className="text-lg">{data.nickname}</p>
+      <article className="my-auto">
+        <h3 className="text-center text-pointColor1 text-xl font-semibold">프로필</h3>
+        <section className="flex gap-20 mt-5">
+          <section className="w-[230px] h-[230px]">
+            <Image
+              src={`${profileStorageUrl}/${data.avatar_img_url}`}
+              alt="사용자 프로필"
+              width={250}
+              height={250}
+              className="bg-bgColor2 w-full h-full object-cover border-solid border border-pointColor1 rounded-full"
+            />
+          </section>
+          <section className="flex flex-col justify-around">
+            <div className="flex flex-col gap-5">
+              <div className="flex flex-col gap-1">
+                <p className="text-pointColor1 font-semibold">닉네임</p>
+                <p className="text-lg">{data.nickname}</p>
+              </div>
+              <div className="flex flex-col gap-1">
+                <p className="text-pointColor1 font-semibold">이메일</p>
+                <p className="text-lg">{data.email}</p>
+              </div>
             </div>
-            <div className="flex flex-col gap-1">
-              <p className="text-pointColor1 font-semibold">이메일</p>
-              <p className="text-lg">{data.email}</p>
+            <div
+              className="text-pointColor1 underline underline-offset-4 cursor-pointer"
+              onClick={() => setIsEditing(true)}
+            >
+              프로필 수정
             </div>
-          </div>
-          <div
-            className="text-pointColor1 underline underline-offset-4 cursor-pointer"
-            onClick={() => setIsEditing(true)}
-          >
-            프로필 수정
-          </div>
+          </section>
         </section>
       </article>
       {isEditing && (

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -49,7 +49,6 @@ const ProfilePage = () => {
     }
   });
 
-  // if (isLoading) return <div className="flex w-full justify-center my-96">로그인 정보를 불러오고 있습니다.</div>;
   if (isLoading) return <LoadingImg height="84vh" />;
   if (!data) return <div>사용자 정보 불러오기 실패</div>;
 


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-465

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [ ] 프로필/점수 영역 세로 중앙 정렬

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
- 맥북에서 이미지가 아래 영역을 넘고 있어서 세로 중앙 정렬했습니다!
여기보다 세로로 더 좁아지면 이미지 다시 겹칩니다.. 🥵
<img width="946" alt="스크린샷 2024-04-19 오전 2 27 38" src="https://github.com/mm-easy/mm-easy/assets/142870577/b29b5394-e296-42a9-b2af-e584c96ca157">
<img width="946" alt="스크린샷 2024-04-19 오전 2 43 36" src="https://github.com/mm-easy/mm-easy/assets/142870577/d5f8127f-5430-420c-bf74-40f5c33236cb">

