### PR TITLE
[style] 타자연습 헤더 텍스트 영역 너비 늘림 & 커뮤니티 글 영역 padding 반응형으로 수정

### DIFF
--- a/src/app/community/list/[category]/CommunityForm.tsx
+++ b/src/app/community/list/[category]/CommunityForm.tsx
@@ -44,8 +44,8 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
   const commentCounts = useQueries({
     queries: sortedItems.map((post) => ({
       queryKey: ['commentCount', post.id],
-      queryFn: () => getCommentCount(post.id),
-    })),
+      queryFn: () => getCommentCount(post.id)
+    }))
   });
 
   const totalSet = Math.ceil(Math.ceil(totalNum / pageRange) / btnRange);
@@ -55,7 +55,7 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
 
   return (
     <article className="w-full ">
-      <div className="bg-white p-4 w-full">
+      <div className="bg-white w-full">
         <table className="w-full">
           <thead className="text-left">
             <tr className="text-pointColor1 font-bold border-b-2 border-solid border-pointColor1">
@@ -80,7 +80,12 @@ const CommunityForm: React.FC<CommunityFormProps> = ({
                 >
                   <td className="pl-6 py-[calc(1.5vh+2px)]">{item['category']}</td>
                   <td>{item.profiles?.nickname || '알 수 없음'}</td>
-                  {item.title} {(commentCounts[idx]?.data ?? 0) > 0 && <span className="text-pointColor1">({commentCounts[idx].data})</span>}
+                  <td>
+                    <span>{item.title}</span>
+                    {(commentCounts[idx]?.data ?? 0) > 0 && (
+                      <span className="text-pointColor1">({commentCounts[idx].data})</span>
+                    )}
+                  </td>
                   <td>{formatToLocaleDateTimeString(item['created_at'])}</td>
                   <td>{item['view_count']}</td>
                 </tr>

--- a/src/app/community/list/[category]/CommunityMain.tsx
+++ b/src/app/community/list/[category]/CommunityMain.tsx
@@ -81,7 +81,7 @@ const CommunityMain = () => {
   }
 
   return (
-    <section className="w-full px-24 flex justify-center mt-[calc(8vh-25px)]">
+    <section className="w-full px-[5vw] flex justify-center mt-[calc(8vh-25px)]">
       <CommunityForm
         currentItems={currentItems}
         setCurrentPage={setCurrentPage}

--- a/src/app/community/list/[category]/[id]/DetailPost.tsx
+++ b/src/app/community/list/[category]/[id]/DetailPost.tsx
@@ -114,7 +114,7 @@ const DetailPost = () => {
 
   return (
     <div className="flex bg-bgColor1 text-pointColor1">
-      <div className="py-16 px-48 w-full bg-white">
+      <div className="py-16 px-[5vw] w-full bg-white">
         {post && post.profiles && (
           <div>
             <div className="flex justify-between">

--- a/src/app/community/write/layout.tsx
+++ b/src/app/community/write/layout.tsx
@@ -9,9 +9,7 @@ const Layout = ({ children }: Props) => {
   return (
     <main className="bg-bgColor1 grid grid-cols-[16%_84%]">
       <section className="h-[84vh] flex flex-col justify-between bg-bgColor1">
-        <div>
-          <CategorySelector categoryNow={''} />
-        </div>
+        <CategorySelector categoryNow={''} />
       </section>
       {children}
     </main>

--- a/src/app/community/write/page.tsx
+++ b/src/app/community/write/page.tsx
@@ -53,7 +53,7 @@ const PostPage = () => {
   };
 
   return (
-    <article className="border-l-2 border-solid border-pointColor1 bg-white px-32 py-16">
+    <article className="border-l-2 border-solid border-pointColor1 bg-white px-[8vw] py-16">
       <PostEditor
         onCancel={handleCancel}
         onSubmit={async ({ category, title, content }) => {

--- a/src/app/typing-game/page.tsx
+++ b/src/app/typing-game/page.tsx
@@ -217,25 +217,25 @@ const TypingGamePage = () => {
     }
   };
 
-  const lifePercentage = (lives / maxLives) * 60;
+  const lifePercentage = (lives / maxLives) * 55;
 
   return (
     <div className="relative flex flex-col bg-[url('https://icnlbuaakhminucvvzcj.supabase.co/storage/v1/object/public/assets/game_bg.png')] bg-cover bg-no-repeat bg-center">
       {gameStarted && (
         <header className="w-full h-[8vh] absolute z-30 flex leading-[7.5vh] font-bold text-xl border-solid border-b-2 border-pointColor1 bg-white">
-          <h2 className="w-[8%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
+          <h2 className="w-[9%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
             난이도
           </h2>
-          <h3 className="w-[8%] h-full text-center text-pointColor2 border-solid border-r-2 border-pointColor1">
+          <h3 className="w-[9%] h-full text-center text-pointColor2 border-solid border-r-2 border-pointColor1">
             {difficultySettings[difficulty].label}
           </h3>
-          <h2 className="w-[8%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
+          <h2 className="w-[9%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
             점수
           </h2>
-          <h3 className="w-[8%] h-full text-center text-pointColor2 border-solid border-r-2 border-pointColor1">
+          <h3 className="w-[9%] h-full text-center text-pointColor2 border-solid border-r-2 border-pointColor1">
             {score}
           </h3>
-          <h2 className="w-[8%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
+          <h2 className="w-[9%] h-full text-center bg-bgColor1 text-pointColor1 border-solid border-r-2 border-pointColor1">
             생명
           </h2>
           <div className="h-[calc(8vh-2px)] bg-pointColor2" style={{ width: `${lifePercentage}%` }}></div>


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-466

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 타자연습 헤더에 텍스트 영역(난이도, 점수 등) 너비 약간 늘림(모바일 직전 크기에서 너무 좁아보여서 늘렸습니다!)
- [x] 커뮤니티 글 영역 padding 반응형으로 수정

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
- 흰 배경 부분 padding-x 5vw 로 잡아놨습니다! 각각 아래가 변경 후 사진입니다.

![스크린샷 2024-04-19 오전 3 07 05](https://github.com/mm-easy/mm-easy/assets/142870577/60738db7-5737-438b-81df-673703818f03)
![스크린샷 2024-04-19 오전 3 07 56](https://github.com/mm-easy/mm-easy/assets/142870577/826d5bb2-00b0-4c62-895f-eb5fd806bd6b)
![스크린샷 2024-04-19 오전 3 22 31](https://github.com/mm-easy/mm-easy/assets/142870577/a59d5e2d-5de6-4212-a67e-1bf45f0befb2)
![스크린샷 2024-04-19 오전 3 23 27](https://github.com/mm-easy/mm-easy/assets/142870577/695e5d79-8c4a-4235-a18c-ced47ca82f3c)