### PR TITLE
[fix/style] 퀴즈, 프로필, 메인 자잘한 CSS & 메인 관리자 퀴즈 표시

### DIFF
--- a/src/app/(main)/QuizSection.tsx
+++ b/src/app/(main)/QuizSection.tsx
@@ -1,13 +1,16 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Pagination, Navigation } from 'swiper/modules';
+
+import { getRecentQuizzes } from '@/api/quizzes';
+import { storageUrl } from '@/utils/supabase/storage';
+import { ADMIN } from '@/constant/adminId';
 import QuestionEx from './QuestionEx';
 import LoadingImg from '@/components/common/LoadingImg';
 import useMultilingual from '@/utils/useMultilingual';
-import { getRecentQuizzes } from '@/api/quizzes';
-import { useQuery } from '@tanstack/react-query';
-import { storageUrl } from '@/utils/supabase/storage';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Pagination, Navigation } from 'swiper/modules';
+import DaejangContent from '@/assets/logo/logo_circle_blue 2.png';
 
 import 'swiper/css';
 import 'swiper/css/navigation';
@@ -47,7 +50,25 @@ const QuizSection = () => {
           {quiz?.map((quiz) => (
             <SwiperSlide key={quiz.id}>
               <div className="p-8 flex flex-col items-center">
-                <p className="font-bold text-lg mt-4 mb-3 truncate">{quiz.title}</p>
+                <div className="flex items-center gap-2">
+                  {ADMIN.some((admin) => admin.id === quiz.creator_id) && (
+                    <Image
+                      src={DaejangContent}
+                      alt="아이콘"
+                      quality={100}
+                      width={20}
+                      height={20}
+                      className="sm:w-4 sm:h-4 w-6 h-6"
+                    />
+                  )}
+                  <p
+                    className={`font-bold text-lg mt-4 mb-3 truncate ${
+                      ADMIN.some((admin) => admin.id === quiz.creator_id) && 'text-pointColor1'
+                    }`}
+                  >
+                    {quiz.title}
+                  </p>
+                </div>
                 <Image
                   src={`${storageUrl}/quiz-thumbnails/${quiz.thumbnail_img_url}`}
                   alt="퀴즈 썸네일"
@@ -71,7 +92,25 @@ const QuizSection = () => {
             key={quiz.id}
             className="p-4 flex flex-col my-5 border border-solid border-grayColor1 rounded-t-3xl rounded-b-md transition duration-300 ease-in-out transform hover:border-blue-500"
           >
-            <p className="font-bold text-lg mt-4 mb-3 truncate">{quiz.title}</p>
+            <div className="flex items-center gap-2">
+              {ADMIN.some((admin) => admin.id === quiz.creator_id) && (
+                <Image
+                  src={DaejangContent}
+                  alt="아이콘"
+                  quality={100}
+                  width={20}
+                  height={20}
+                  className="sm:w-4 sm:h-4 w-6 h-6"
+                />
+              )}
+              <p
+                className={`font-bold text-lg mt-4 mb-3 truncate ${
+                  ADMIN.some((admin) => admin.id === quiz.creator_id) && 'text-pointColor1'
+                }`}
+              >
+                {quiz.title}
+              </p>
+            </div>
             <div className="flex flex-col gap-3">
               <Image
                 src={`${storageUrl}/quiz-thumbnails/${quiz.thumbnail_img_url}`}

--- a/src/app/(main)/QuizSection.tsx
+++ b/src/app/(main)/QuizSection.tsx
@@ -65,7 +65,7 @@ const QuizSection = () => {
           ))}
         </Swiper>
       </div>
-      <section className="px-6 py-4 grid grid-cols-4 gap-5 flex:block sm:hidden">
+      <section className="px-11 py-4 grid grid-cols-4 gap-10 flex:block sm:hidden">
         {quiz?.map((quiz) => (
           <div
             key={quiz.id}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -258,15 +258,20 @@ const AboutPage = () => {
                 <div className="my-8">
                   {member.Github ? (
                     <div className="flex gap-2 items-center justify-center">
-                      <WhiteButton onClick={() => handleGitBtn(member.Github)} text="Github" />
-                      <WhiteButton onClick={() => handleBlogBtn(member.Blog)} text="Blog" />
+                      <WhiteButton onClick={() => handleGitBtn(member.Github)} text="Github" py="py-2" />
+                      <WhiteButton onClick={() => handleBlogBtn(member.Blog)} text="Blog" py="py-2" />
                     </div>
                   ) : (
                     <div className="flex gap-2 items-center justify-center">
-                      <WhiteButton onClick={() => member.Behance && handleGitBtn(member.Behance)} text="Behance" />
+                      <WhiteButton
+                        onClick={() => member.Behance && handleGitBtn(member.Behance)}
+                        text="Behance"
+                        py="py-2"
+                      />
                       <WhiteButton
                         onClick={() => member.Instagram && handleGitBtn(member.Instagram)}
                         text="Instagram"
+                        py="py-2"
                       />
                     </div>
                   )}

--- a/src/app/profile/MyProfile.tsx
+++ b/src/app/profile/MyProfile.tsx
@@ -84,8 +84,8 @@ const MyProfile = ({ data }: { data: User }) => {
   return (
     <main className="w-full h-full flex flex-col items-center">
       <article className="my-auto">
-        <h3 className="sm:hidden text-center text-pointColor1 text-xl font-semibold">{m('HEADER')}</h3>
-        <section className="flex sm:flex-col sm:gap-7 gap-20 m-10">
+        <h3 className="sm:hidden text-center text-pointColor1 text-xl font-bold">{m('HEADER')}</h3>
+        <section className="flex sm:flex-col sm:gap-7 gap-20 mt-[5vh] mb-[2vh]">
           <section className="w-[230px] h-[230px]">
             <Image
               src={`${profileStorageUrl}/${data.avatar_img_url}`}

--- a/src/app/quiz/[id]/PageAndSubmitBtn.tsx
+++ b/src/app/quiz/[id]/PageAndSubmitBtn.tsx
@@ -25,7 +25,7 @@ const PageAndSubmitBtn = ({
         <div className="flex justify-between gap-3 font-semibold">
           <button
             disabled={page === 0}
-            className={`w-full py-[9px] ${
+            className={`w-full py-[7px] ${
               page === 0 ? 'text-white bg-grayColor2' : 'text-pointColor1 border border-solid border-pointColor1'
             } rounded-md`}
             onClick={handlePrevPage}
@@ -34,7 +34,7 @@ const PageAndSubmitBtn = ({
           </button>
           <button
             disabled={page === questionsLength - 1}
-            className={`w-full py-[9px] ${
+            className={`w-full py-[7px] ${
               page === questionsLength - 1
                 ? 'text-white bg-grayColor2'
                 : 'text-pointColor1 border border-solid border-pointColor1'
@@ -46,9 +46,9 @@ const PageAndSubmitBtn = ({
         </div>
       )}
       <button
-        className={`w-full py-2.5 ${
+        className={`w-full py-[8px] ${
           isAllAnswersSubmitted ? 'bg-pointColor1' : 'bg-grayColor2 cursor-default'
-        } text-white font-bold tracking-wider rounded-md`}
+        } text-white font-semibold tracking-wider rounded-md`}
         onClick={handleResultMode}
       >
         {resultMode ? m('RETRY_BTN') : m('SUBMIT_BTN')}

--- a/src/app/quiz/list/QuizList.tsx
+++ b/src/app/quiz/list/QuizList.tsx
@@ -53,9 +53,9 @@ const QuizList = ({
 
   return (
     <main className="sm:p-1 p-5 flex flex-col justify-center items-center">
-      <div className="w-full flex sm:justify-center items-center gap-1 sm:pl-0 sm:pb-3 pl-7 pt-5">
-        <Image src={DaejangContent} alt="아이콘" quality={100} width={30} height={30} />
-        <p className="sm:w-[300px] text-sm font-bold">{m('OFFICIAL_CONTENTS')}</p>
+      <div className="w-full flex sm:justify-center items-center gap-2 sm:pl-0 sm:pb-3 pl-7 pt-5">
+        <Image src={DaejangContent} alt="아이콘" quality={100} width={24} height={24} />
+        <p className="sm:w-[85%] text-sm font-bold">{m('OFFICIAL_CONTENTS')}</p>
       </div>
       <div className="sm:py-0 sm:px-3 px-6 py-4 grid grid-cols-4 sm:grid-cols-2 sm:gap-3 gap-10">
         {allQuizzes
@@ -68,19 +68,19 @@ const QuizList = ({
                 handleShowModal(item.id);
               }}
             >
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-2">
                 {ADMIN.some((admin) => admin.id === item.creator_id) && (
                   <Image
                     src={DaejangContent}
                     alt="아이콘"
                     quality={100}
-                    width={30}
-                    height={30}
-                    className="sm:w-6 sm:h-6 w-8 h-8"
+                    width={20}
+                    height={20}
+                    className="sm:w-4 sm:h-4 w-6 h-6"
                   />
                 )}
                 <p
-                  className={`font-bold sm:text-base text-lg sm:mt-2 mt-4 sm:mb-1 mb-3 truncate ${
+                  className={`font-bold sm:text-base sm:mt-2 mt-4 sm:mb-1 mb-3 text-lg truncate ${
                     ADMIN.some((admin) => admin.id === item.creator_id) && 'text-pointColor1'
                   }`}
                 >

--- a/src/app/quiz/list/SelectQuizLevel.tsx
+++ b/src/app/quiz/list/SelectQuizLevel.tsx
@@ -158,7 +158,7 @@ const SelectQuizLevel = () => {
           <p className="sm:block sm:font-bold sm:text-pointColor1 sm:mt-5 hidden">{m('QUIZ_LEVEL_3')}</p>
         </div>
       </main>
-      <main className="sm:hidden w-full h-[400px] bg-bgColor2 border-b-2 border-pointColor1 flex flex-col justify-center items-center">
+      <main className="sm:hidden w-full h-[452px] bg-bgColor2 border-b-2 border-pointColor1 flex flex-col justify-center items-center">
         <div className="mt-5 absolute top-20 z-10 flex flex-col items-center">
           <p className="text-pointColor1 text-3xl font-bold">{m('SELECT_LEVEL_TITLE')}</p>
           <p
@@ -198,7 +198,7 @@ const SelectQuizLevel = () => {
               quality={100}
               className={`w-full h-full transform transition-transform duration-500 ease-in-out border-solid border-2 border-pointColor1 rounded-[30px] rotate-[-2deg] cursor-pointer ${
                 selectedLevel === 2
-                  ? 'translate-y-[65%] z-10'
+                  ? 'translate-y-[60%] z-10'
                   : selectedLevel === null
                     ? 'z-0 translate-y-[70%] hover:translate-y-[65%]'
                     : 'z-0 translate-y-[80%] hover:translate-y-[70%]'

--- a/src/app/quiz/list/SelectQuizLevel.tsx
+++ b/src/app/quiz/list/SelectQuizLevel.tsx
@@ -169,7 +169,7 @@ const SelectQuizLevel = () => {
           </p>
         </div>
         <div className="mt-5 mr-1/4 absolute top-20 z-10 left-3/4">
-          <WhiteButton text={m('CREATE_QUIZ_BTN')} onClick={() => handleMakeQuizBtn()} width="w-36" />
+          <WhiteButton text={m('CREATE_QUIZ_BTN')} onClick={() => handleMakeQuizBtn()} width="w-36" py="py-3" />
         </div>
         <div className="flex items-end overflow-hidden mt-30">
           <div className="rotate-[-5deg] ml-5">

--- a/src/app/quiz/list/SelectQuizLevel.tsx
+++ b/src/app/quiz/list/SelectQuizLevel.tsx
@@ -1,18 +1,6 @@
 'use client';
 
 import Image from 'next/image';
-import QuizList from './QuizList';
-import Level1 from '@/assets/quiz/level1.png';
-import Level2 from '@/assets/quiz/level2.png';
-import Level3 from '@/assets/quiz/level3.png';
-import Level1ENG from '@/assets/quiz/card_en_easy.png';
-import Level2ENG from '@/assets/quiz/card_en_medium.png';
-import Level3ENG from '@/assets/quiz/card_en_hard.png';
-import MobileL0 from '@/assets/quiz/face_2.png';
-import MobileL1 from '@/assets/quiz/face_3.png';
-import MobileL2 from '@/assets/quiz/face_4.png';
-import MobileL3 from '@/assets/quiz/face_5.png';
-import LoadingImg from '@/components/common/LoadingImg';
 import { WhiteButton } from '@/components/common/FormButtons';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -24,9 +12,22 @@ import { toast } from 'react-toastify';
 import { useAtom } from 'jotai';
 import { langAtom } from '@/store/store';
 
-import type { Quiz } from '@/types/quizzes';
-import useMultilingual from '@/utils/useMultilingual';
+import QuizList from './QuizList';
 import CreateNewQuizBtn from './CreateNewQuizBtn';
+import Level1 from '@/assets/quiz/level1.png';
+import Level2 from '@/assets/quiz/level2.png';
+import Level3 from '@/assets/quiz/level3.png';
+import MobileL0 from '@/assets/quiz/face_2.png';
+import MobileL1 from '@/assets/quiz/face_3.png';
+import MobileL2 from '@/assets/quiz/face_4.png';
+import MobileL3 from '@/assets/quiz/face_5.png';
+import Level1ENG from '@/assets/quiz/card_en_easy.png';
+import Level2ENG from '@/assets/quiz/card_en_medium.png';
+import Level3ENG from '@/assets/quiz/card_en_hard.png';
+import LoadingImg from '@/components/common/LoadingImg';
+import useMultilingual from '@/utils/useMultilingual';
+
+import type { Quiz } from '@/types/quizzes';
 
 const SelectQuizLevel = () => {
   const router = useRouter();
@@ -161,7 +162,7 @@ const SelectQuizLevel = () => {
         <div className="mt-5 absolute top-20 z-10 flex flex-col items-center">
           <p className="text-pointColor1 text-3xl font-bold">{m('SELECT_LEVEL_TITLE')}</p>
           <p
-            className="text-pointColor1 underline underline-offset-4 text-lg font-bold mt-5 cursor-pointer"
+            className="text-pointColor1 underline underline-offset-4 font-bold mt-5 cursor-pointer"
             onClick={() => handleSelectLevel(null)}
           >
             {m('SEE_ALL_QUIZZES')}

--- a/src/components/common/FormButtons.tsx
+++ b/src/components/common/FormButtons.tsx
@@ -1,6 +1,7 @@
 interface FormButtonProps {
   onClick?: () => void;
   text: string;
+  py?: string;
   width?: string;
   height?: string;
   border?: string;
@@ -42,12 +43,12 @@ export const BlueButton: React.FC<FormButtonProps> = ({ onClick, text, width, he
   );
 };
 
-export const WhiteButton: React.FC<FormButtonProps> = ({ onClick, text, width }) => {
+export const WhiteButton: React.FC<FormButtonProps> = ({ onClick, text, py, width }) => {
   return (
     <button
       type="submit"
       onClick={onClick}
-      className={`rounded-md text-pointColor1 border-solid p-2 border border-pointColor1 bg-white ${width}`}
+      className={`rounded-md text-pointColor1 border-solid px-2 ${py} border border-pointColor1 bg-white ${width}`}
     >
       {text}
     </button>

--- a/src/components/layout/ProfileDropdown.tsx
+++ b/src/components/layout/ProfileDropdown.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { getUser } from '@/api/users';
 import { supabase } from '@/utils/supabase/supabase';
-import { DropdownItem, DropdownTrigger, Dropdown, DropdownMenu, Avatar } from '@nextui-org/react';
+import { extendVariants, DropdownItem, DropdownTrigger, Dropdown, DropdownMenu, Avatar } from '@nextui-org/react';
 import { toast } from 'react-toastify';
 import { useQuery } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
@@ -22,6 +22,19 @@ const ProfileDropdown = () => {
 
   const { logout } = useAuth();
   const route = useRouter();
+
+  const MyAvatar = extendVariants(Avatar, {
+    variants: {
+      color: {
+        white: {
+          base: ['bg-white']
+        }
+      }
+    },
+    defaultVariants: {
+      color: 'white'
+    }
+  });
 
   /** 로그아웃 핸들러 */
   const handleLogout = async () => {
@@ -55,10 +68,10 @@ const ProfileDropdown = () => {
     <div className="flex items-center gap-4">
       <Dropdown placement="bottom-end">
         <DropdownTrigger>
-          <Avatar
+          <MyAvatar
             as="button"
             className="transition-transform"
-            color="default"
+            color="white"
             size="md"
             src={`${profileStorageUrl}/${data?.avatar_img_url}`}
           />

--- a/src/constant/locales/my-page/my-profile.ts
+++ b/src/constant/locales/my-page/my-profile.ts
@@ -56,7 +56,7 @@ const MY_PROFILE_STRINGS = {
     en: 'Total Score'
   },
   TO_MY_ACTIVITY: {
-    ko: '나의 활동 보러가기',
+    ko: '나의 활동 보러 가기',
     en: 'To My Activity'
   },
   CANCEL_EDITING: {


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-609
🔗 https://coding-legend.atlassian.net/browse/MMEASY-610
🔗 https://coding-legend.atlassian.net/browse/MMEASY-611
🔗 https://coding-legend.atlassian.net/browse/MMEASY-612
🔗 https://coding-legend.atlassian.net/browse/MMEASY-613

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 퀴즈 리스트 전체보기 font size 작게
- [x] 퀴즈 리스트 레벨 이미지 얼굴 더 보이도록
- [x] 퀴즈 만들기 버튼 py 크게
- [x] 퀴즈 리스트 관리자 마크 크기 작게
- [x] 퀴즈 풀기 페이지, 제출 버튼 py 작게
- [x] 헤더 기본 프로필 배경 white로 변경
- [x] 메인 퀴즈 리스트 px 수정, 관리자 마크 표시
- [x] 나의 프로필 margin height 반응형으로 수정

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
- next ui 컬러 변경 방법입니다! 불러왔던 Avatar 를 MyAvatar 로 다시 지정해줬습니다!

ProfileDropdown.tsx
```tsx
import { extendVariants, DropdownItem, DropdownTrigger, Dropdown, DropdownMenu, Avatar } from '@nextui-org/react';

  const MyAvatar = extendVariants(Avatar, {
    variants: {
      color: {
        white: {
          base: ['bg-white']
        }
      }
    },
    defaultVariants: {
      color: 'white'
    }
  });
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
<img width="281" alt="스크린샷 2024-04-28 오전 1 23 52" src="https://github.com/mm-easy/mm-easy/assets/142870577/32bac343-e717-4028-9e95-c80c78c2c9be">
<img width="377" alt="스크린샷 2024-04-28 오전 2 14 11" src="https://github.com/mm-easy/mm-easy/assets/142870577/2fc86e4e-f7cf-46a2-bb3c-af19458e89c0">

## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->
- 퀴즈 리스트에 레벨 이미지 높이를 메인 배너 부분이랑 맞춰놨는데, 혹시 너무 길면 말씀해 주세요!