### PR TITLE
[feat] 퀴즈 풀기 페이지 삭제버튼 추가

### DIFF
--- a/src/app/community/list/[category]/[id]/Comment.tsx
+++ b/src/app/community/list/[category]/[id]/Comment.tsx
@@ -121,6 +121,7 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
                       onChange={(e) => setContentChange(e.target.value)}
                       placeholder="Reply to comment…"
                     />
+                    <p className='sm:h-[19px] h-[11px]'></p>
                   </div>
                 ) : (
                   <div className="sm:w-[70vw]">
@@ -190,7 +191,7 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
                       </button>
                       {prev.isOpen &&
                         (btnChange && prev.id === nowCommentId ? (
-                          <div className="absolute flex flex-col right-0 mt-2 w-20 border-solid border border-pointColor1 bg-white rounded-md z-20">
+                          <div className="absolute flex flex-col right-0 mt-2 w-32 border-solid border border-pointColor1 bg-white rounded-md z-20">
                             <button className="py-2 pr-2 font-bold" onClick={() => handleUpdateBtn(prev.id)}>
                               {m('COMMUNITY_COMMENT_SAVE')}
                             </button>
@@ -205,12 +206,12 @@ const Comment: React.FC<PostCommentProps> = ({ postId, profile }) => {
                             </button>
                           </div>
                         ) : (
-                          <div className="absolute flex flex-col right-0 mt-2 w-20 border-solid border border-pointColor1 bg-white rounded-md z-20">
-                            <button className="py-2 font-bold" onClick={() => handleIsOpenChangeBtn(prev.content, prev.id)}>
+                          <div className="absolute flex flex-col right-0 mt-2 w-32 border-solid border border-pointColor1 bg-white rounded-md z-20">
+                            <button className="h-10 py-2 font-bold" onClick={() => handleIsOpenChangeBtn(prev.content, prev.id)}>
                               {m('COMMUNITY_COMMENT_EDIT')}
                             </button>
                             <hr className="border-t border-0.5 border-pointColor1" />
-                            <button className="py-2 font-bold" onClick={() => handleDeleteBtn(prev.id)}>
+                            <button className="h-10 py-2 font-bold" onClick={() => handleDeleteBtn(prev.id)}>
                               {m('COMMUNITY_COMMENT_DELETE')}
                             </button>
                           </div>

--- a/src/app/community/list/[category]/[id]/DetailPost.tsx
+++ b/src/app/community/list/[category]/[id]/DetailPost.tsx
@@ -166,7 +166,7 @@ const DetailPost = () => {
                         <time className="text-sm">{formatToLocaleDateTimeString(post.created_at)}</time>
                       </div>
                     </div>
-                    <div className="flex items-center">
+                    <div className="flex items-center sm:pr-4">
                       {profile &&
                         (post.author_id === profile.id || ADMIN.some((admin) => admin.id === profile?.email)) && (
                           <>
@@ -176,8 +176,8 @@ const DetailPost = () => {
                                   text={m('COMMUNITY_POST_EDIT')}
                                   postId={post.id}
                                   redirectUrl={`/community/list/${categoryNow}/${post.id}/edit`}
-                                  width="w-20"
-                                  height="h-12"
+                                  width="w-16"
+                                  height="h-10"
                                 />
                               }
                               deleteBtn={
@@ -185,8 +185,8 @@ const DetailPost = () => {
                                   text={m('COMMUNITY_POST_DELETE')}
                                   redirectUrl={'/community/list/전체'}
                                   postId={post.id}
-                                  width="w-20"
-                                  height="h-12"
+                                  width="w-16"
+                                  height="h-10"
                                 />
                               }
                             />

--- a/src/app/community/list/[category]/[id]/edit/page.tsx
+++ b/src/app/community/list/[category]/[id]/edit/page.tsx
@@ -79,7 +79,7 @@ const EditPage = ({ params }: { params: { id: string; category: string } }) => {
 
   // TODO : 조건부로 랜더링
   return (
-    <article className="bg-white px-32 py-16 border-l-2 border-solid border-pointColor1">
+    <article className="sm:border-l-0 sm:py-0 sm:px-0 bg-white px-32 py-16 border-l-2 border-solid border-pointColor1">
       <PostEditor
         defaultValues={{
           category: post.category,

--- a/src/app/community/write/PostEditor.tsx
+++ b/src/app/community/write/PostEditor.tsx
@@ -107,7 +107,7 @@ const PostEditor = ({ defaultValues, onCancel, onSubmit }: Props) => {
       <div>
         <TextEditor value={textEditorValue} onChange={setTextEditorValue} />
       </div>
-      <div className="sm:py-6 sm:mt-0 mt-[calc(8vh-50px)] flex justify-center gap-5 font-bold">
+      <div className="sm:pb-28 sm:py-6 sm:mt-0 mt-[calc(8vh-50px)] flex justify-center gap-5 font-bold">
         <CancelButton
           text={m('COMMUNITY_POST_CANCEL')}
           onClick={onCancel}

--- a/src/app/quiz/[id]/Header.tsx
+++ b/src/app/quiz/[id]/Header.tsx
@@ -2,26 +2,46 @@ import { useRouter } from 'next/navigation';
 import useMultilingual from '@/utils/useMultilingual';
 import ExitButton from '@/components/common/ExitButton';
 import HeaderTitle from './HeaderTitle';
+import { QuizDropdown } from './QuizDorpdown';
+import { CancelButton } from '@/components/common/FormButtons';
+import { useQueryClient } from '@tanstack/react-query';
+import { useDeleteQuiz } from './mutations';
+import { toast } from 'react-toastify';
 
 const Header = ({
   level,
   title,
   isAnswerWritten,
-  resultMode
+  resultMode,
+  id
 }: {
   level: number;
   title: string;
   isAnswerWritten: number;
   resultMode: boolean;
+  id: string;
 }) => {
   const m = useMultilingual('quiz-try');
   const router = useRouter();
+  const queryClient = useQueryClient();
+  const deleteQuizMutation = useDeleteQuiz();
 
   const handleExitBtn = () => {
     if (isAnswerWritten && !resultMode) {
       if (!window.confirm(m('ASK_TO_EXIT'))) return;
     }
     router.push('/quiz/list');
+  };
+
+  const handleDeleteQuiz = (id: string) => {
+    if (!window.confirm(m('ASK_TO_DELETE'))) return;
+    deleteQuizMutation.mutateAsync(id, {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['quizzes', id] });
+        toast.success(m('NOTIFY_TO_DELETE'));
+        router.replace('/quiz/list');
+      }
+    });
   };
 
   return (
@@ -31,10 +51,29 @@ const Header = ({
       </h2>
       <section className="w-[calc(84%-2px)] flex justify-between">
         <div className="w-[95%] flex sm:flex-col">
-          <HeaderTitle>{m('LEVEL')}</HeaderTitle>
-          <h3 className="w-[10%] sm:w-full sm:h-3/4 sm:pl-4 text-center sm:text-left sm:font-semibold sm:text-pointColor1 border-solid border-r-2 border-pointColor1 sm:border-0">
-            {level === 1 ? m('QUIZ_LEVEL_1') : level === 2 ? m('QUIZ_LEVEL_2') : m('QUIZ_LEVEL_3')}
-          </h3>
+          <div className="sm:block hidden">
+            <HeaderTitle>{m('LEVEL')}</HeaderTitle>
+            <div className="w-[100vw] flex justify-between">
+              <div>
+                <h3 className="w-[10%] sm:w-full sm:h-3/4 sm:pl-4 text-center sm:text-left sm:font-semibold sm:text-pointColor1 border-solid border-r-2 border-pointColor1 sm:border-0">
+                  {level === 1 ? m('QUIZ_LEVEL_1') : level === 2 ? m('QUIZ_LEVEL_2') : m('QUIZ_LEVEL_3')}
+                </h3>
+              </div>
+              <div className='pr-4 font-bold'>
+                <QuizDropdown
+                  deleteBtn={
+                    <CancelButton
+                      text={m('DELETE_BTN')}
+                      width="w-32"
+                      height="h-12"
+                      border="border-1"
+                      onClick={() => handleDeleteQuiz(id as string)}
+                    />
+                  }
+                />
+              </div>
+            </div>
+          </div>
           <HeaderTitle>{m('TITLE')}</HeaderTitle>
           <h3 className="sm:w-full pl-[2%] sm:pl-4 sm:text-xl sm:font-semibold">{title}</h3>
         </div>

--- a/src/app/quiz/[id]/QuizDorpdown.tsx
+++ b/src/app/quiz/[id]/QuizDorpdown.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { HiDotsVertical } from 'react-icons/hi';
+
+export const QuizDropdown = ({ deleteBtn }: { deleteBtn: React.ReactNode }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const userMenuOnBlur = () => {
+    setTimeout(() => {
+      setIsOpen(false);
+    }, 200);
+  };
+  return (
+    <div className="relative ">
+      <button onClick={() => setIsOpen(!isOpen)} onBlur={userMenuOnBlur} className="focus:outline-none text-pointColor1">
+        <HiDotsVertical />
+      </button>
+      {isOpen && (
+        <div className="absolute right-0 top-12 ">
+          {deleteBtn}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/quiz/[id]/SideHeader.tsx
+++ b/src/app/quiz/[id]/SideHeader.tsx
@@ -57,7 +57,7 @@ const SideHeader = ({
           quality={100}
           className="w-full h-[230px] sm:hidden object-cover border-solid border-b-2 border-pointColor1"
         />
-        <p className="pl-4 pt-4 hidden sm:block">{info}</p>
+        <p className="sm:pt-10 pl-4 pt-4 hidden sm:block">{info}</p>
         <CreateInfo creator={creator} date={formatToLocaleDateTimeString(date)} />
         <p className="p-4 sm:hidden">{info}</p>
       </section>

--- a/src/app/quiz/[id]/page.tsx
+++ b/src/app/quiz/[id]/page.tsx
@@ -289,7 +289,7 @@ const QuizTryPage = () => {
           <MobileHeader backPage="/quiz/list" text="퀴즈 결과" />
         </div>
       )}
-      <Header level={level} title={title} isAnswerWritten={usersAnswers.length} resultMode={resultMode} />
+      <Header level={level} title={title} isAnswerWritten={usersAnswers.length} resultMode={resultMode} id={id}/>
       <div className="grid grid-cols-[16%_84%] sm:pb-[8vh] sm:block bg-bgColor1 sm:bg-white">
         <SideHeader
           url={url}

--- a/src/components/common/DeleteButton.tsx
+++ b/src/components/common/DeleteButton.tsx
@@ -36,7 +36,7 @@ export const PostDeleteButton: React.FC<FormPostButtonProps> = ({ text, width, h
       onClick={handleDeleteClick}
       className={`${
         params.id
-          ? 'font-bold rounded-md text-white border-solid p-2 border border-pointColor1 bg-pointColor1 sm:font-normal sm:text-pointColor1 sm:border-0 sm:bg-transparent'
+          ? 'sm:w-full font-bold rounded-md text-white border-solid p-2 border border-pointColor1 bg-pointColor1 sm:font-bold sm:text-pointColor1 sm:border-0 sm:bg-transparent'
           : 'sm:rounded-sm font-bold rounded-md text-white border-solid p-2 border border-pointColor1 bg-pointColor1'
       } ${width} ${height}`}
     >

--- a/src/components/common/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { HiDotsVertical } from 'react-icons/hi';
 
 export const DropdownMenu = ({ editBtn, deleteBtn }: { editBtn: React.ReactNode; deleteBtn: React.ReactNode }) => {
@@ -15,9 +15,9 @@ export const DropdownMenu = ({ editBtn, deleteBtn }: { editBtn: React.ReactNode;
         <HiDotsVertical />
       </button>
       {isOpen && (
-        <div className="absolute flex flex-col right-0 mt-2 py-2 w-32 border-solid border border-pointColor1 bg-white rounded-md z-20">
+        <div className="absolute flex flex-col right-0 mt-2 w-32 border-solid border border-pointColor1 bg-white rounded-md z-20">
           {editBtn}
-          <hr className="border-t border-0.5 border-pointColor1" />
+          <hr className="border-t-1 border-solid border-pointColor1" />
           {deleteBtn}
         </div>
       )}

--- a/src/components/common/EditButton.tsx
+++ b/src/components/common/EditButton.tsx
@@ -14,7 +14,7 @@ export const PostEditButton: React.FC<FormPostButtonProps> = ({ text, width, hei
     <button
       type="submit"
       onClick={handleEditClick}
-      className={`font-bold rounded-md text-pointColor1 border-solid p-2 border border-pointColor1 bg-white sm:font-normal sm:text-pointColor1 sm:border-0 sm:bg-transparent ${width} ${height}`}
+      className={`sm:w-full font-bold rounded-md text-pointColor1 border-solid p-2 border border-pointColor1 bg-white sm:font-bold sm:text-pointColor1 sm:border-0 sm:bg-transparent ${width} ${height}`}
     >
       {text}
     </button>

--- a/src/components/common/FormButtons.tsx
+++ b/src/components/common/FormButtons.tsx
@@ -6,13 +6,13 @@ interface FormButtonProps {
   height?: string;
   border?: string;
 }
-
+// flex justify-center items-center 퀴즈풀기 때문에 추가했으니 문제 있는지 확인해보기..
 export const CancelButton: React.FC<FormButtonProps> = ({ onClick, text, width, height, border }) => {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`sm:border-1 rounded-md text-pointColor1 border-solid p-2 border border-pointColor1 bg-white ${width} ${height} ${border}`}
+      className={`flex justify-center items-center sm:border-1 rounded-md text-pointColor1 border-solid p-2 border border-pointColor1 bg-white ${width} ${height} ${border}`}
     >
       {text}
     </button>


### PR DESCRIPTION
## 📍 관련 이슈
<!-- Jira 에픽 링크를 넣어주세요. -->
🔗 https://coding-legend.atlassian.net/browse/MMEASY-622

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요. -->
- [x] 퀴즈 풀기 페이지 삭제버튼 추가
- [x] 커뮤니티 상세페이지 드롭다운 css 수정

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요. -->
현재 퀴즈에 삭제 드롭다운 넣긴 했는데 본인 게시글만 조건부 렌더링 추가해야 합니다.. 일단은 로직 넣기 전까진 드롭다운
주석처리 해둔 상태로 올립니다..!

- Header.tsx
```tsx
 <div className='pr-4 font-bold'>
                {/* <QuizDropdown
                  deleteBtn={
                    <CancelButton
                      text={m('DELETE_BTN')}
                      width="w-32"
                      height="h-12"
                      border="border-1"
                      onClick={() => handleDeleteQuiz(id as string)}
                    />
                  }
                /> */}
              </div>
```

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요. -->
![image](https://github.com/mm-easy/mm-easy/assets/139940350/ff014962-c593-40f7-8a32-3dcafb830207)


## 📔 레퍼런스, 새로 알게 된 것, 궁금한 사항 등 공유할 내용
<!-- 참고할 사항이 있다면 적어주세요. -->

드롭다운에 조건부 렌더링 추가해야합니다!